### PR TITLE
fix: HTTPリクエストのメトリクスに設定するタグを、実際のリクエストパスからクラス名とメソッド名に変更

### DIFF
--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
@@ -1,0 +1,126 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link HttpRequestMetricsTagBuilder}のデフォルト実装。
+ * <p>
+ * タグのリストは以下の内容で作成する。
+ * <table>
+ *   <tr>
+ *     <th>タグ</th>
+ *     <th>説明</th>
+ *   </tr>
+ *   <tr>
+ *     <td>class</td>
+ *     <td>リクエストを処理したクラスの名前（HTTPステータスが {@code 404} 、または取得できない場合は {@code UNKNOWN}）</td>
+ *   </tr>
+ *   <tr>
+ *     <td>method</td>
+ *     <td>リクエストを処理したメソッドの名前（HTTPステータスが {@code 404} 、取得できない場合は {@code UNKNOWN}）</td>
+ *   </tr>
+ *   <tr>
+ *     <td>httpMethod</td>
+ *     <td>HTTPメソッド</td>
+ *   </tr>
+ *   <tr>
+ *     <td>status</td>
+ *     <td>HTTPステータスコード</td>
+ *   </tr>
+ *   <tr>
+ *     <td>outcome</td>
+ *     <td>
+ *       HTTPステータスコードの種類を表す文字列。<br>
+ *       1XX は {@code INFORMATION}, 2XX は {@code SUCCESS}, 3XX は {@code REDIRECTION},
+ *       4XX は {@code CLIENT_ERROR}, 5XX は {@code SERVER_ERROR}, それ以外の場合は {@code UNKNOWN}。
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>exception</td>
+ *     <td>例外がスローされた場合は、そのクラスの単純名（スローされていない場合は {@code "None"}）</td>
+ *   </tr>
+ * </table>
+ * </p>
+ */
+public class DefaultHttpRequestMetricsTagBuilder implements HttpRequestMetricsTagBuilder {
+    /**
+     * アクションクラス名をリクエストスコープから取得するときのデフォルトのキー。
+     */
+    static final String DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME = "nablarch_request_mapping_class";
+    /**
+     * アクションクラスのメソッド名をリクエストスコープから取得するときのデフォルトのキー。
+     */
+    static final String DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME = "nablarch_request_mapping_method";
+
+    private String requestMappingClassVarName = DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME;
+    private String requestMappingMethodVarName = DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME;
+
+    @Override
+    public List<Tag> build(HttpRequest request, ExecutionContext context, Throwable thrownThrowable) {
+        List<Tag> tagList = new ArrayList<>();
+
+        HttpServletResponse servletResponse = ((ServletExecutionContext) context).getServletResponse();
+
+        tagList.add(Tag.of("httpMethod", request.getMethod()));
+        tagList.add(Tag.of("status", String.valueOf(servletResponse.getStatus())));
+        tagList.add(Tag.of("outcome", resolveOutcome(servletResponse.getStatus())));
+        tagList.add(Tag.of("exception", resolveException(context, thrownThrowable)));
+
+        if (servletResponse.getStatus() == HttpServletResponse.SC_NOT_FOUND) {
+            tagList.add(Tag.of("class", "UNKNOWN"));
+            tagList.add(Tag.of("method", "UNKNOWN"));
+        } else {
+            String className = context.getRequestScopedVar(requestMappingClassVarName);
+            String methodName = context.getRequestScopedVar(requestMappingMethodVarName);
+
+            tagList.add(Tag.of("class", className != null ? className : "UNKNOWN"));
+            tagList.add(Tag.of("method", methodName != null ? methodName : "UNKNOWN"));
+        }
+
+        return tagList;
+    }
+
+    private String resolveOutcome(int statusCode) {
+        if (100 <= statusCode && statusCode < 200) {
+            return "INFORMATION";
+        } else if (200 <= statusCode && statusCode < 300) {
+            return "SUCCESS";
+        } else if (300 <= statusCode && statusCode < 400) {
+            return "REDIRECTION";
+        } else if (400 <= statusCode && statusCode < 500) {
+            return "CLIENT_ERROR";
+        } else if (500 <= statusCode && statusCode < 600) {
+            return "SERVER_ERROR";
+        } else {
+            return "UNKNOWN";
+        }
+    }
+
+    private String resolveException(ExecutionContext context, Throwable cachedThrowable) {
+        Throwable throwable = cachedThrowable != null ? cachedThrowable : context.getException();
+        return throwable == null ? "None" : throwable.getClass().getSimpleName();
+    }
+
+    /**
+     * アクションクラス名をリクエストスコープから取得するときのキーを指定する。
+     * @param requestMappingClassVarName アクションクラス名のキー
+     */
+    public void setRequestMappingClassVarName(String requestMappingClassVarName) {
+        this.requestMappingClassVarName = requestMappingClassVarName;
+    }
+
+    /**
+     * アクションクラスのメソッド名をリクエストスコープから取得するときのキーを指定する。
+     * @param requestMappingMethodVarName アクションクラスのメソッド名のキー
+     */
+    public void setRequestMappingMethodVarName(String requestMappingMethodVarName) {
+        this.requestMappingMethodVarName = requestMappingMethodVarName;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandler.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandler.java
@@ -1,72 +1,27 @@
 package nablarch.integration.micrometer.instrument.handler.http;
 
 import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import nablarch.fw.ExecutionContext;
 import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.HttpRequestHandler;
 import nablarch.fw.web.HttpResponse;
-import nablarch.fw.web.servlet.ServletExecutionContext;
 
-import javax.servlet.http.HttpServletResponse;
+import java.util.List;
 
 /**
  * HTTPリクエストの処理時間をメトリクスとして収集するハンドラ。
  * <p>
- * メトリクスは、 {@code http.server.requests} という名前で作成される。<br>
- * また、メトリクスには以下のタグが設定される。
- * <table>
- *   <tr>
- *     <th>タグ</th>
- *     <th>説明</th>
- *   </tr>
- *   <tr>
- *     <td>class</td>
- *     <td>リクエストを処理したクラスの名前（取得できない場合は {@code UNKNOWN}）</td>
- *   </tr>
- *   <tr>
- *     <td>method</td>
- *     <td>リクエストを処理したメソッドの名前（取得できない場合は {@code UNKNOWN}）</td>
- *   </tr>
- *   <tr>
- *     <td>httpMethod</td>
- *     <td>HTTPメソッド</td>
- *   </tr>
- *   <tr>
- *     <td>status</td>
- *     <td>HTTPステータスコード</td>
- *   </tr>
- *   <tr>
- *     <td>outcome</td>
- *     <td>
- *       HTTPステータスコードの種類を表す文字列。<br>
- *       1XX は {@code INFORMATION}, 2XX は {@code SUCCESS}, 3XX は {@code REDIRECTION},
- *       4XX は {@code CLIENT_ERROR}, 5XX は {@code SERVER_ERROR}, それ以外の場合は {@code UNKNOWN}。
- *     </td>
- *   </tr>
- *   <tr>
- *     <td>exception</td>
- *     <td>例外がスローされた場合は、そのクラスの単純名（スローされていない場合は {@code "None"}）</td>
- *   </tr>
- * </table>
+ * メトリクスは、 {@code http.server.requests} という名前で作成される。
  * </p>
  *
  * @author Tanaka Tomoyuki
  */
 public class HttpRequestMetricsHandler implements HttpRequestHandler {
-    /**
-     * アクションクラス名をリクエストスコープから取得するときのデフォルトのキー。
-     */
-    static final String DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME = "nablarch_request_mapping_class";
-    /**
-     * アクションクラスのメソッド名をリクエストスコープから取得するときのデフォルトのキー。
-     */
-    static final String DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME = "nablarch_request_mapping_method";
 
     private MeterRegistry meterRegistry;
-
-    private String requestMappingClassVarName = DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME;
-    private String requestMappingMethodVarName = DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME;
+    private HttpRequestMetricsTagBuilder httpRequestMetricsTagBuilder = new DefaultHttpRequestMetricsTagBuilder();
 
     @Override
     public HttpResponse handle(HttpRequest request, ExecutionContext context) {
@@ -76,48 +31,16 @@ public class HttpRequestMetricsHandler implements HttpRequestHandler {
 
         Timer.Sample sample = Timer.start(meterRegistry);
 
-        Throwable cachedThrowable = null;
+        Throwable thrownThrowable = null;
         try {
             return context.handleNext(request);
         } catch (Throwable th) {
-            cachedThrowable = th;
+            thrownThrowable = th;
             throw th;
         } finally {
-            Timer timer = buildTimer(request, context, cachedThrowable);
+            List<Tag> tagList = httpRequestMetricsTagBuilder.build(request, context, thrownThrowable);
+            Timer timer = Timer.builder("http.server.requests").tags(tagList).register(meterRegistry);
             sample.stop(timer);
-        }
-    }
-
-    private Timer buildTimer(HttpRequest request, ExecutionContext context, Throwable cachedThrowable) {
-        HttpServletResponse servletResponse = ((ServletExecutionContext) context).getServletResponse();
-        Throwable throwable = cachedThrowable != null ? cachedThrowable : context.getException();
-
-        String className = context.getRequestScopedVar(requestMappingClassVarName);
-        String methodName = context.getRequestScopedVar(requestMappingMethodVarName);
-
-        return Timer.builder("http.server.requests")
-                .tag("class", className != null ? className : "UNKNOWN")
-                .tag("method", methodName != null ? methodName : "UNKNOWN")
-                .tag("httpMethod", request.getMethod())
-                .tag("status", String.valueOf(servletResponse.getStatus()))
-                .tag("outcome", resolveOutcome(servletResponse.getStatus()))
-                .tag("exception", throwable == null ? "None" : throwable.getClass().getSimpleName())
-                .register(meterRegistry);
-    }
-
-    private String resolveOutcome(int statusCode) {
-        if (100 <= statusCode && statusCode < 200) {
-            return "INFORMATION";
-        } else if (200 <= statusCode && statusCode < 300) {
-            return "SUCCESS";
-        } else if (300 <= statusCode && statusCode < 400) {
-            return "REDIRECTION";
-        } else if (400 <= statusCode && statusCode < 500) {
-            return "CLIENT_ERROR";
-        } else if (500 <= statusCode && statusCode < 600) {
-            return "SERVER_ERROR";
-        } else {
-            return "UNKNOWN";
         }
     }
 
@@ -130,18 +53,10 @@ public class HttpRequestMetricsHandler implements HttpRequestHandler {
     }
 
     /**
-     * アクションクラス名をリクエストスコープから取得するときのキーを指定する。
-     * @param requestMappingClassVarName アクションクラス名のキー
+     * {@link HttpRequestMetricsTagBuilder}を設定する。
+     * @param httpRequestMetricsTagBuilder {@link HttpRequestMetricsTagBuilder}
      */
-    public void setRequestMappingClassVarName(String requestMappingClassVarName) {
-        this.requestMappingClassVarName = requestMappingClassVarName;
-    }
-
-    /**
-     * アクションクラスのメソッド名をリクエストスコープから取得するときのキーを指定する。
-     * @param requestMappingMethodVarName アクションクラスのメソッド名のキー
-     */
-    public void setRequestMappingMethodVarName(String requestMappingMethodVarName) {
-        this.requestMappingMethodVarName = requestMappingMethodVarName;
+    public void setHttpRequestMetricsTagBuilder(HttpRequestMetricsTagBuilder httpRequestMetricsTagBuilder) {
+        this.httpRequestMetricsTagBuilder = httpRequestMetricsTagBuilder;
     }
 }

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsTagBuilder.java
@@ -1,0 +1,23 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+
+import java.util.List;
+
+/**
+ * {@link HttpRequestMetricsHandler}でメトリクスに設定するタグのリスト生成機能を提供するインタフェース。
+ * @author Tanaka Tomoyuki
+ */
+public interface HttpRequestMetricsTagBuilder {
+
+    /**
+     * メトリクスに設定するタグのリストを生成する。
+     * @param request HTTPリクエスト
+     * @param context 実行時のコンテキスト
+     * @param thrownThrowable 後続ハンドラによってスローされた例外(例外がスローされていない場合は {@code null})
+     * @return 生成したタグのリスト
+     */
+    List<Tag> build(HttpRequest request, ExecutionContext context, Throwable thrownThrowable);
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderTest.java
@@ -1,0 +1,168 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+/**
+ * {@link DefaultHttpRequestMetricsTagBuilder}の単体テスト。
+ */
+public class DefaultHttpRequestMetricsTagBuilderTest {
+    @Mocked
+    private HttpRequest request;
+    @Mocked
+    private ServletExecutionContext context;
+    @Mocked
+    private HttpServletResponse servletResponse;
+
+    private DefaultHttpRequestMetricsTagBuilder sut = new DefaultHttpRequestMetricsTagBuilder();
+
+    @Before
+    public void setUp() {
+        new Expectations() {{
+            context.getServletResponse(); result = servletResponse;
+        }};
+    }
+
+    @Test
+    public void testStandardCase() {
+        new Expectations() {{
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "hello";
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+            Tag.of("class", "foo.bar.TestController"),
+            Tag.of("method", "hello"),
+            Tag.of("httpMethod", "GET"),
+            Tag.of("status", "200"),
+            Tag.of("outcome", "SUCCESS"),
+            Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testThrownThrowableIsNotNull() {
+        new Expectations() {{
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "throwable";
+
+            request.getMethod(); result = "POST";
+            servletResponse.getStatus(); result = 500;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, new NullPointerException("test"));
+
+        assertThat(tagList, containsInAnyOrder(
+            Tag.of("class", "foo.bar.TestController"),
+            Tag.of("method", "throwable"),
+            Tag.of("httpMethod", "POST"),
+            Tag.of("status", "500"),
+            Tag.of("outcome", "SERVER_ERROR"),
+            Tag.of("exception", "NullPointerException")
+        ));
+    }
+
+    @Test
+    public void testThrownThrowableIsNullButContextHasException() {
+        new Expectations() {{
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "exception";
+            context.getException(); returns(new IllegalArgumentException("test"), null);
+
+            request.getMethod(); result = "PUT";
+            servletResponse.getStatus(); result = 500;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", "foo.bar.TestController"),
+                Tag.of("method", "exception"),
+                Tag.of("httpMethod", "PUT"),
+                Tag.of("status", "500"),
+                Tag.of("outcome", "SERVER_ERROR"),
+                Tag.of("exception", "IllegalArgumentException")
+        ));
+    }
+
+    @Test
+    public void testStatusIsNotFound() {
+        new Expectations() {{
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 404;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", "UNKNOWN"),
+                Tag.of("method", "UNKNOWN"),
+                Tag.of("httpMethod", "GET"),
+                Tag.of("status", "404"),
+                Tag.of("outcome", "CLIENT_ERROR"),
+                Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testClassAndMethodAreNull() {
+        new Expectations() {{
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = null;
+            context.getRequestScopedVar(DefaultHttpRequestMetricsTagBuilder.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = null;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", "UNKNOWN"),
+                Tag.of("method", "UNKNOWN"),
+                Tag.of("httpMethod", "GET"),
+                Tag.of("status", "200"),
+                Tag.of("outcome", "SUCCESS"),
+                Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testChangeClassAndMethodVarNames() {
+        new Expectations() {{
+            context.getRequestScopedVar("test_class_name"); result = "fizz.buzz.TestController";
+            context.getRequestScopedVar("test_method_name"); result = "execute";
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        sut.setRequestMappingClassVarName("test_class_name");
+        sut.setRequestMappingMethodVarName("test_method_name");
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", "fizz.buzz.TestController"),
+                Tag.of("method", "execute"),
+                Tag.of("httpMethod", "GET"),
+                Tag.of("status", "200"),
+                Tag.of("outcome", "SUCCESS"),
+                Tag.of("exception", "None")
+        ));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerOutcomeTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerOutcomeTest.java
@@ -68,8 +68,9 @@ public class HttpRequestMetricsHandlerOutcomeTest {
             context.handleNext(request); result = response;
             context.getServletResponse(); result = httpServletResponse;
 
+            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
+            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "test";
             request.getMethod(); result = "PUT";
-            request.getRequestPath(); result = "/test/path";
             httpServletResponse.getStatus(); result = fixture.statusCode;
         }};
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerTest.java
@@ -1,6 +1,7 @@
 package nablarch.integration.micrometer.instrument.handler.http;
 
 import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import mockit.Expectations;
@@ -11,7 +12,7 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -28,9 +29,9 @@ public class HttpRequestMetricsHandlerTest {
     @Mocked
     private HttpResponse response;
     @Mocked
-    private HttpServletResponse httpServletResponse;
-    @Mocked
     private ServletExecutionContext context;
+    @Mocked
+    private HttpRequestMetricsTagBuilder tagBuilder;
 
     private HttpRequestMetricsHandler sut;
     private SimpleMeterRegistry registry;
@@ -38,25 +39,16 @@ public class HttpRequestMetricsHandlerTest {
     @Before
     public void setUp() {
         sut = new HttpRequestMetricsHandler();
+        sut.setHttpRequestMetricsTagBuilder(tagBuilder);
         registry = new SimpleMeterRegistry();
         sut.setMeterRegistry(registry);
     }
 
-    private void setupNormalCaseExpectation() {
-        new Expectations() {{
-            context.handleNext(request); result = response;
-            context.getServletResponse(); result = httpServletResponse;
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "hello";
-
-            request.getMethod(); result = "GET";
-            httpServletResponse.getStatus(); result = 200;
-        }};
-    }
-
     @Test
     public void testInvokeNextHandler() {
-        setupNormalCaseExpectation();
+        new Expectations() {{
+            context.handleNext(request); result = response;
+        }};
 
         HttpResponse response = sut.handle(request, context);
 
@@ -64,117 +56,35 @@ public class HttpRequestMetricsHandlerTest {
     }
 
     @Test
-    public void testTimerNormalCase() {
-        setupNormalCaseExpectation();
+    public void testMeasureTime() {
+        new Expectations() {{
+            context.handleNext(request); result = response;
+
+            tagBuilder.build(request, context, null);
+            result = Arrays.asList(Tag.of("foo", "FOO"), Tag.of("bar", "BAR"));
+        }};
 
         sut.handle(request, context);
 
         Timer timer = registry.get("http.server.requests").timer();
-        Meter.Id id = timer.getId();
-
-        assertThat(id.getTag("class"), is("foo.bar.TestController"));
-        assertThat(id.getTag("method"), is("hello"));
-        assertThat(id.getTag("httpMethod"), is("GET"));
-        assertThat(id.getTag("status"), is("200"));
-        assertThat(id.getTag("outcome"), is("SUCCESS"));
-        assertThat(id.getTag("exception"), is("None"));
         assertThat(timer.count(), is(1L));
+
+        Meter.Id id = timer.getId();
+        assertThat(id.getTag("foo"), is("FOO"));
+        assertThat(id.getTag("bar"), is("BAR"));
     }
 
     @Test
     public void testTimerThrowsExceptionCase() {
         new Expectations() {{
             context.handleNext(request); result = new Throwable("test throwable");
-            context.getServletResponse(); result = httpServletResponse;
-
-            request.getMethod(); result = "POST";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestErrorController";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "throwError";
-            httpServletResponse.getStatus(); result = 500;
         }};
 
         Throwable throwable = assertThrows(Throwable.class, () -> sut.handle(request, context));
         assertThat(throwable.getMessage(), is("test throwable"));
 
         Timer timer = registry.get("http.server.requests").timer();
-        Meter.Id id = timer.getId();
-
-        assertThat(id.getTag("class"), is("foo.bar.TestErrorController"));
-        assertThat(id.getTag("method"), is("throwError"));
-        assertThat(id.getTag("httpMethod"), is("POST"));
-        assertThat(id.getTag("status"), is("500"));
-        assertThat(id.getTag("outcome"), is("SERVER_ERROR"));
-        assertThat(id.getTag("exception"), is("Throwable"));
         assertThat(timer.count(), is(1L));
-    }
-
-    @Test
-    public void testTimerReturnsErrorResponseCase() {
-        new Expectations() {{
-            context.handleNext(request); result = response;
-            context.getServletResponse(); result = httpServletResponse;
-            context.getException(); returns(new NullPointerException("test null"), null);
-
-            request.getMethod(); result = "PUT";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = "foo.bar.TestController";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = "error";
-            httpServletResponse.getStatus(); result = 500;
-        }};
-
-        sut.handle(request, context);
-
-        Timer timer = registry.get("http.server.requests").timer();
-        Meter.Id id = timer.getId();
-
-        assertThat(id.getTag("class"), is("foo.bar.TestController"));
-        assertThat(id.getTag("method"), is("error"));
-        assertThat(id.getTag("httpMethod"), is("PUT"));
-        assertThat(id.getTag("status"), is("500"));
-        assertThat(id.getTag("outcome"), is("SERVER_ERROR"));
-        assertThat(id.getTag("exception"), is("NullPointerException"));
-        assertThat(timer.count(), is(1L));
-    }
-
-    @Test
-    public void testClassAndMethodIsUnknown() {
-        new Expectations() {{
-            context.handleNext(request); result = response;
-            context.getServletResponse(); result = httpServletResponse;
-
-            request.getMethod(); result = "GET";
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_CLASS_VAR_NAME); result = null;
-            context.getRequestScopedVar(HttpRequestMetricsHandler.DEFAULT_REQUEST_MAPPING_METHOD_VAR_NAME); result = null;
-        }};
-
-        sut.handle(request, context);
-
-        Timer timer = registry.get("http.server.requests").timer();
-        Meter.Id id = timer.getId();
-
-        assertThat(id.getTag("class"), is("UNKNOWN"));
-        assertThat(id.getTag("method"), is("UNKNOWN"));
-    }
-
-    @Test
-    public void testChangeControllerAndActionVarNames() {
-        new Expectations() {{
-            context.handleNext(request); result = response;
-            context.getServletResponse(); result = httpServletResponse;
-
-            request.getMethod(); result = "GET";
-            context.getRequestScopedVar("test_class_name"); result = "foo.bar.TestAction";
-            context.getRequestScopedVar("test_method_name"); result = "execute";
-        }};
-
-        sut.setRequestMappingClassVarName("test_class_name");
-        sut.setRequestMappingMethodVarName("test_method_name");
-        sut.handle(request, context);
-
-        Timer timer = registry.get("http.server.requests").timer();
-        Meter.Id id = timer.getId();
-
-        assertThat(id.getTag("class"), is("foo.bar.TestAction"));
-        assertThat(id.getTag("method"), is("execute"));
     }
 
     @Test


### PR DESCRIPTION
- メトリクスに設定していた `path` タグを削除
- 代わりに、 nablarch-router-adaptor で設定されているはずのアクションクラス名とメソッド名をタグで設定するように修正
    - クラス名 : `class`
    - メソッド名 : `method`
- 既存の HTTP メソッドを設定していたタグは、上記 `method` と区別しやすいようにタグ名を `httpMethod` に変更
- リクエストスコープに値が設定されていない場合は、固定で `UNKNOWN` を設定するようにしています
