### PR TITLE
feat: HTTPリクエストの処理時間をメトリクスとして収集するハンドラを追加

### DIFF
--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
@@ -8,7 +8,6 @@ import nablarch.fw.web.servlet.ServletExecutionContext;
 
 import javax.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
-import java.lang.reflect.Parameter;
 import java.util.Arrays;
 import java.util.List;
 
@@ -96,8 +95,8 @@ public class DefaultHttpRequestMetricsTagBuilder implements HttpRequestMetricsTa
     private String buildMethodTag(Method method) {
         StringBuilder sb = new StringBuilder(method.getName());
 
-        for (Parameter parameter : method.getParameters()) {
-            sb.append("_").append(parameter.getType().getCanonicalName());
+        for (Class<?> parameterType : method.getParameterTypes()) {
+            sb.append("_").append(parameterType.getCanonicalName());
         }
 
         return sb.toString();

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
@@ -1,0 +1,126 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.handler.MethodBinding;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+
+import javax.servlet.http.HttpServletResponse;
+import java.lang.reflect.Method;
+import java.lang.reflect.Parameter;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * {@link HttpRequestMetricsTagBuilder}のデフォルト実装。
+ * <p>
+ * タグのリストは以下の内容で作成する。
+ * <table>
+ *   <tr>
+ *     <th>タグ</th>
+ *     <th>説明</th>
+ *   </tr>
+ *   <tr>
+ *     <td>class</td>
+ *     <td>
+ *       リクエストを処理したクラスの名前({@link Class#getName()})。<br>
+ *       クラスの情報を取得できない場合は {@code UNKNOWN}。
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>method</td>
+ *     <td>
+ *       リクエストを処理したメソッドを表す文字列。<br>
+ *       この文字列は、メソッド名の後ろに引数の型の正規名({@link Class#getCanonicalName()})をアンダースコア({@code _})で
+ *       つなげたものになる（例:{@code fooMethod_int_java.lang.String}）。<br>
+ *       メソッドの情報を取得できない場合は {@code UNKNOWN}。
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>httpMethod</td>
+ *     <td>HTTPメソッド</td>
+ *   </tr>
+ *   <tr>
+ *     <td>status</td>
+ *     <td>HTTPステータスコード</td>
+ *   </tr>
+ *   <tr>
+ *     <td>outcome</td>
+ *     <td>
+ *       HTTPステータスコードの種類を表す文字列。<br>
+ *       1XX は {@code INFORMATION}, 2XX は {@code SUCCESS}, 3XX は {@code REDIRECTION},
+ *       4XX は {@code CLIENT_ERROR}, 5XX は {@code SERVER_ERROR}, それ以外の場合は {@code UNKNOWN}。
+ *     </td>
+ *   </tr>
+ *   <tr>
+ *     <td>exception</td>
+ *     <td>例外がスローされた場合は、そのクラスの単純名（スローされていない場合は {@code "None"}）</td>
+ *   </tr>
+ * </table>
+ * </p>
+ */
+public class DefaultHttpRequestMetricsTagBuilder implements HttpRequestMetricsTagBuilder {
+
+    @Override
+    public List<Tag> build(HttpRequest request, ExecutionContext context, Throwable thrownThrowable) {
+        Class<?> clazz = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS);
+        Method method = context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD);
+        HttpServletResponse servletResponse = ((ServletExecutionContext) context).getServletResponse();
+
+        /*
+         * タグ仕様の背景説明
+         *
+         * ここで設定しているタグは、 Spring Boot Actuator の Spring MVC Metrics が設定しているタグを参考にしている。
+         * ただし、 Actuator は uri タグを設定しているのに対して、本メトリクスでは class, method を設定している違いがある。
+         * Actuator の uri は、リクエストを受けたパスの定義(/project/{id})が設定される。
+         * しかし、このパス定義に該当する情報は、 Nablarch が利用している HTTP Request Router から取得できない。
+         * したがって、本メトリクスでは uri の代わりに実行されたアクションクラスとメソッドの情報を出力している。
+         * 参考: https://spring.pleiades.io/spring-boot/docs/2.3.4.RELEASE/reference/html/production-ready-features.html#production-ready-metrics-spring-mvc
+         *
+         * class, method タグの出力書式については、 Eclipse Microprofile の Metrics の仕様を参考にしている。
+         * また、 class が Class#getName() で method の引数の型が Class#getCanonicalName() である点については、
+         * Microprofile の Metrics を実装している Open Liberty の実際の動作を参考にしている。
+         * 参考: https://download.eclipse.org/microprofile/microprofile-metrics-2.3/microprofile-metrics-spec-2.3.html#_optional_rest
+         */
+        return Arrays.asList(
+            Tag.of("class", clazz != null ? clazz.getName() : "UNKNOWN"),
+            Tag.of("method", method != null ? buildMethodTag(method) : "UNKNOWN"),
+            Tag.of("httpMethod", request.getMethod()),
+            Tag.of("status", String.valueOf(servletResponse.getStatus())),
+            Tag.of("outcome", resolveOutcome(servletResponse.getStatus())),
+            Tag.of("exception", resolveException(context, thrownThrowable))
+        );
+    }
+
+    private String buildMethodTag(Method method) {
+        StringBuilder sb = new StringBuilder(method.getName());
+
+        for (Parameter parameter : method.getParameters()) {
+            sb.append("_").append(parameter.getType().getCanonicalName());
+        }
+
+        return sb.toString();
+    }
+
+    private String resolveOutcome(int statusCode) {
+        if (100 <= statusCode && statusCode < 200) {
+            return "INFORMATION";
+        } else if (200 <= statusCode && statusCode < 300) {
+            return "SUCCESS";
+        } else if (300 <= statusCode && statusCode < 400) {
+            return "REDIRECTION";
+        } else if (400 <= statusCode && statusCode < 500) {
+            return "CLIENT_ERROR";
+        } else if (500 <= statusCode && statusCode < 600) {
+            return "SERVER_ERROR";
+        } else {
+            return "UNKNOWN";
+        }
+    }
+
+    private String resolveException(ExecutionContext context, Throwable cachedThrowable) {
+        Throwable throwable = cachedThrowable != null ? cachedThrowable : context.getException();
+        return throwable == null ? "None" : throwable.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilder.java
@@ -118,8 +118,8 @@ public class DefaultHttpRequestMetricsTagBuilder implements HttpRequestMetricsTa
         }
     }
 
-    private String resolveException(ExecutionContext context, Throwable cachedThrowable) {
-        Throwable throwable = cachedThrowable != null ? cachedThrowable : context.getException();
+    private String resolveException(ExecutionContext context, Throwable thrownThrowable) {
+        Throwable throwable = thrownThrowable != null ? thrownThrowable : context.getException();
         return throwable == null ? "None" : throwable.getClass().getSimpleName();
     }
 }

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandler.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandler.java
@@ -1,0 +1,65 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpRequestHandler;
+import nablarch.fw.web.HttpResponse;
+
+import java.util.List;
+
+/**
+ * HTTPリクエストの処理時間をメトリクスとして収集するハンドラ。
+ * <p>
+ * メトリクスは、 {@code http.server.requests} という名前で作成される。
+ * </p>
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class HttpRequestMetricsHandler implements HttpRequestHandler {
+
+    private MeterRegistry meterRegistry;
+    private HttpRequestMetricsTagBuilder httpRequestMetricsTagBuilder = new DefaultHttpRequestMetricsTagBuilder();
+
+    @Override
+    public HttpResponse handle(HttpRequest request, ExecutionContext context) {
+        if (meterRegistry == null) {
+            throw new IllegalStateException("meterRegistry is not set.");
+        }
+
+        Timer.Sample sample = Timer.start(meterRegistry);
+
+        Throwable thrownThrowable = null;
+        try {
+            return context.handleNext(request);
+        } catch (Throwable th) {
+            thrownThrowable = th;
+            throw th;
+        } finally {
+            List<Tag> tagList = httpRequestMetricsTagBuilder.build(request, context, thrownThrowable);
+            Timer timer = Timer.builder("http.server.requests")
+                    .description("HTTP request metrics measured by Timer.")
+                    .tags(tagList)
+                    .register(meterRegistry);
+            sample.stop(timer);
+        }
+    }
+
+    /**
+     * {@link MeterRegistry}を設定する。
+     * @param meterRegistry {@link MeterRegistry}
+     */
+    public void setMeterRegistry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * {@link HttpRequestMetricsTagBuilder}を設定する。
+     * @param httpRequestMetricsTagBuilder {@link HttpRequestMetricsTagBuilder}
+     */
+    public void setHttpRequestMetricsTagBuilder(HttpRequestMetricsTagBuilder httpRequestMetricsTagBuilder) {
+        this.httpRequestMetricsTagBuilder = httpRequestMetricsTagBuilder;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsTagBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsTagBuilder.java
@@ -1,0 +1,23 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import nablarch.fw.ExecutionContext;
+import nablarch.fw.web.HttpRequest;
+
+import java.util.List;
+
+/**
+ * {@link HttpRequestMetricsHandler}でメトリクスに設定するタグのリスト生成機能を提供するインタフェース。
+ * @author Tanaka Tomoyuki
+ */
+public interface HttpRequestMetricsTagBuilder {
+
+    /**
+     * メトリクスに設定するタグのリストを生成する。
+     * @param request HTTPリクエスト
+     * @param context 実行時のコンテキスト
+     * @param thrownThrowable 後続ハンドラによってスローされた例外(例外がスローされていない場合は {@code null})
+     * @return 生成したタグのリスト
+     */
+    List<Tag> build(HttpRequest request, ExecutionContext context, Throwable thrownThrowable);
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderOutcomeTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderOutcomeTest.java
@@ -1,0 +1,87 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.handler.MethodBinding;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * {@link DefaultHttpRequestMetricsTagBuilder}の outcome タグのパターンをテストするクラス。
+ * @author Tanaka Tomoyuki
+ */
+@RunWith(Parameterized.class)
+public class DefaultHttpRequestMetricsTagBuilderOutcomeTest {
+    @Parameterized.Parameters
+    public static List<Fixture> parameters() {
+        return Arrays.asList(
+            fixture(99, "UNKNOWN"),
+            fixture(100, "INFORMATION"),
+            fixture(199, "INFORMATION"),
+            fixture(200, "SUCCESS"),
+            fixture(299, "SUCCESS"),
+            fixture(300, "REDIRECTION"),
+            fixture(399, "REDIRECTION"),
+            fixture(400, "CLIENT_ERROR"),
+            fixture(499, "CLIENT_ERROR"),
+            fixture(500, "SERVER_ERROR"),
+            fixture(599, "SERVER_ERROR"),
+            fixture(600, "UNKNOWN")
+        );
+    }
+
+    @Mocked
+    private HttpRequest request;
+    @Mocked
+    private HttpServletResponse httpServletResponse;
+    @Mocked
+    private ServletExecutionContext context;
+
+    private final Fixture fixture;
+
+    public DefaultHttpRequestMetricsTagBuilderOutcomeTest(Fixture fixture) {
+        this.fixture = fixture;
+    }
+
+    @Test
+    public void test() {
+        DefaultHttpRequestMetricsTagBuilder sut = new DefaultHttpRequestMetricsTagBuilder();
+
+        new Expectations() {{
+            context.getServletResponse(); result = httpServletResponse;
+
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_WITHOUT_ARGS;
+            request.getMethod(); result = "PUT";
+            httpServletResponse.getStatus(); result = fixture.statusCode;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+        assertThat("statusCode=" + fixture.statusCode, tagList, hasItem(Tag.of("outcome", fixture.expectedOutcome)));
+    }
+
+    private static Fixture fixture(int statusCode, String expectedOutcome) {
+        return new Fixture(statusCode, expectedOutcome);
+    }
+
+    private static class Fixture {
+        private final int statusCode;
+        private final String expectedOutcome;
+
+        private Fixture(int statusCode, String expectedOutcome) {
+            this.statusCode = statusCode;
+            this.expectedOutcome = expectedOutcome;
+        }
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/DefaultHttpRequestMetricsTagBuilderTest.java
@@ -1,0 +1,209 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Tag;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.handler.MethodBinding;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.servlet.http.HttpServletResponse;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+
+/**
+ * {@link DefaultHttpRequestMetricsTagBuilder}の単体テスト。
+ */
+public class DefaultHttpRequestMetricsTagBuilderTest {
+    @Mocked
+    private HttpRequest request;
+    @Mocked
+    private ServletExecutionContext context;
+    @Mocked
+    private HttpServletResponse servletResponse;
+
+    private DefaultHttpRequestMetricsTagBuilder sut = new DefaultHttpRequestMetricsTagBuilder();
+
+    @Before
+    public void setUp() {
+        new Expectations() {{
+            context.getServletResponse(); result = servletResponse;
+        }};
+    }
+
+    @Test
+    public void testStandardCase() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_WITHOUT_ARGS;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+            Tag.of("class", TestController.class.getName()),
+            Tag.of("method", TestController.ACTION_METHOD_WITHOUT_ARGS.getName()),
+            Tag.of("httpMethod", "GET"),
+            Tag.of("status", "200"),
+            Tag.of("outcome", "SUCCESS"),
+            Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testMethodHasArguments() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_WITH_ARGS;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 404;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", TestController.class.getName()),
+                Tag.of("method", "withArgs_int_java.lang.String"),
+                Tag.of("httpMethod", "GET"),
+                Tag.of("status", "404"),
+                Tag.of("outcome", "CLIENT_ERROR"),
+                Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testThrownThrowableIsNotNull() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_WITHOUT_ARGS;
+
+            request.getMethod(); result = "POST";
+            servletResponse.getStatus(); result = 500;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, new NullPointerException("test"));
+
+        assertThat(tagList, containsInAnyOrder(
+            Tag.of("class", TestController.class.getName()),
+            Tag.of("method", TestController.ACTION_METHOD_WITHOUT_ARGS.getName()),
+            Tag.of("httpMethod", "POST"),
+            Tag.of("status", "500"),
+            Tag.of("outcome", "SERVER_ERROR"),
+            Tag.of("exception", "NullPointerException")
+        ));
+    }
+
+    @Test
+    public void testThrownThrowableIsNullButContextHasException() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_WITHOUT_ARGS;
+            context.getException(); returns(new IllegalArgumentException("test"), null);
+
+            request.getMethod(); result = "PUT";
+            servletResponse.getStatus(); result = 500;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+            Tag.of("class", TestController.class.getName()),
+            Tag.of("method", TestController.ACTION_METHOD_WITHOUT_ARGS.getName()),
+            Tag.of("httpMethod", "PUT"),
+            Tag.of("status", "500"),
+            Tag.of("outcome", "SERVER_ERROR"),
+            Tag.of("exception", "IllegalArgumentException")
+        ));
+    }
+
+    @Test
+    public void testClassAndMethodAreNull() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = null;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = null;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, containsInAnyOrder(
+                Tag.of("class", "UNKNOWN"),
+                Tag.of("method", "UNKNOWN"),
+                Tag.of("httpMethod", "GET"),
+                Tag.of("status", "200"),
+                Tag.of("outcome", "SUCCESS"),
+                Tag.of("exception", "None")
+        ));
+    }
+
+    @Test
+    public void testMethodArgumentFormatArray() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_ARRAY;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, hasItem(Tag.of("method", "array_java.lang.String[]")));
+    }
+
+    @Test
+    public void testMethodArgumentFormatNestedArray() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_NESTED_ARRAY;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, hasItem(Tag.of("method", "nestedArray_java.lang.String[][]")));
+    }
+
+    @Test
+    public void testMethodArgumentFormatMemberClass() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.ACTION_METHOD_MEMBER_CLASS;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, hasItem(Tag.of("method", "memberClass_nablarch.integration.micrometer.instrument.handler.http.TestController.MemberClass")));
+    }
+
+    @Test
+    public void testClassFormatMemberClass() {
+        new Expectations() {{
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_CLASS); result = TestController.MemberController.class;
+            context.getRequestScopedVar(MethodBinding.SCOPE_VAR_NAME_BOUND_METHOD); result = TestController.MemberController.ACTION_METHOD;
+
+            request.getMethod(); result = "GET";
+            servletResponse.getStatus(); result = 200;
+        }};
+
+        List<Tag> tagList = sut.build(request, context, null);
+
+        assertThat(tagList, hasItem(Tag.of("class", "nablarch.integration.micrometer.instrument.handler.http.TestController$MemberController")));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/HttpRequestMetricsHandlerTest.java
@@ -1,0 +1,98 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.web.HttpRequest;
+import nablarch.fw.web.HttpResponse;
+import nablarch.fw.web.servlet.ServletExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * {@link HttpRequestMetricsHandler}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class HttpRequestMetricsHandlerTest {
+    @Mocked
+    private HttpRequest request;
+    @Mocked
+    private HttpResponse response;
+    @Mocked
+    private ServletExecutionContext context;
+    @Mocked
+    private HttpRequestMetricsTagBuilder tagBuilder;
+
+    private HttpRequestMetricsHandler sut;
+    private SimpleMeterRegistry registry;
+
+    @Before
+    public void setUp() {
+        sut = new HttpRequestMetricsHandler();
+        sut.setHttpRequestMetricsTagBuilder(tagBuilder);
+        registry = new SimpleMeterRegistry();
+        sut.setMeterRegistry(registry);
+    }
+
+    @Test
+    public void testInvokeNextHandler() {
+        new Expectations() {{
+            context.handleNext(request); result = response;
+        }};
+
+        HttpResponse response = sut.handle(request, context);
+
+        assertThat(response, is(sameInstance(response)));
+    }
+
+    @Test
+    public void testMeasureTime() {
+        new Expectations() {{
+            context.handleNext(request); result = response;
+
+            tagBuilder.build(request, context, null);
+            result = Arrays.asList(Tag.of("foo", "FOO"), Tag.of("bar", "BAR"));
+        }};
+
+        sut.handle(request, context);
+
+        Timer timer = registry.get("http.server.requests").timer();
+        assertThat(timer.count(), is(1L));
+
+        Meter.Id id = timer.getId();
+        assertThat(id.getTag("foo"), is("FOO"));
+        assertThat(id.getTag("bar"), is("BAR"));
+        assertThat(id.getDescription(), is("HTTP request metrics measured by Timer."));
+    }
+
+    @Test
+    public void testTimerThrowsExceptionCase() {
+        new Expectations() {{
+            context.handleNext(request); result = new Throwable("test throwable");
+        }};
+
+        Throwable throwable = assertThrows(Throwable.class, () -> sut.handle(request, context));
+        assertThat(throwable.getMessage(), is("test throwable"));
+
+        Timer timer = registry.get("http.server.requests").timer();
+        assertThat(timer.count(), is(1L));
+    }
+
+    @Test
+    public void testThrowsExceptionIfMeterRegistryIsNull() {
+        sut.setMeterRegistry(null);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> sut.handle(request, context));
+        assertThat(exception.getMessage(), is("meterRegistry is not set."));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/http/TestController.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/http/TestController.java
@@ -1,0 +1,99 @@
+package nablarch.integration.micrometer.instrument.handler.http;
+
+import java.lang.reflect.Method;
+import java.util.List;
+
+/**
+ * {@link DefaultHttpRequestMetricsTagBuilder}の {@code class} と {@code method} タグの
+ * フォーマットを検証するためのテスト用コントローラクラス。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class TestController {
+    /**
+     * 引数なしのメソッド。
+     */
+    static final Method ACTION_METHOD_WITHOUT_ARGS;
+
+    /**
+     * 引数が複数存在するメソッド。
+     */
+    static final Method ACTION_METHOD_WITH_ARGS;
+
+    /**
+     * 引数が配列のメソッド。
+     */
+    static final Method ACTION_METHOD_ARRAY;
+
+    /**
+     * 引数が入れ子の（多次元）配列のメソッド。
+     */
+    static final Method ACTION_METHOD_NESTED_ARRAY;
+
+    /**
+     * 引数がメンバークラスのメソッド。
+     */
+    static final Method ACTION_METHOD_MEMBER_CLASS;
+
+    /**
+     * 引数が入れ子のメンバークラスのメソッド。
+     */
+    static final Method ACTION_METHOD_NESTED_MEMBER_CLASS;
+
+    /**
+     * 引数に総称型の型が使われているメソッド。
+     */
+    static final Method ACTION_METHOD_GENERIC;
+
+    static {
+        try {
+            ACTION_METHOD_WITHOUT_ARGS = TestController.class.getMethod("withoutArgs");
+            ACTION_METHOD_WITH_ARGS = TestController.class.getMethod("withArgs", int.class, String.class);
+            ACTION_METHOD_ARRAY = TestController.class.getMethod("array", String[].class);
+            ACTION_METHOD_NESTED_ARRAY = TestController.class.getMethod("nestedArray", String[][].class);
+            ACTION_METHOD_MEMBER_CLASS = TestController.class.getMethod("memberClass", MemberClass.class);
+            ACTION_METHOD_NESTED_MEMBER_CLASS = TestController.class.getMethod("nestedMemberClass", MemberClass.NestedMemberClass.class);
+            ACTION_METHOD_GENERIC = TestController.class.getMethod("generic", List.class);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public void withoutArgs() {}
+
+    public void withArgs(int number, String text) {}
+
+    public void array(String[] array) {}
+
+    public void nestedArray(String[][] nestedArray) {}
+
+    public void memberClass(MemberClass memberClass) {}
+
+    public void nestedMemberClass(MemberClass.NestedMemberClass nestedMemberClass) {}
+
+    public void generic(List<String> generic) {}
+
+    /**
+     * メソッド引数がメンバークラスのケースを検証するためのクラス。
+     */
+    public static class MemberClass {
+        public static class NestedMemberClass {}
+    }
+
+    /**
+     * コントローラがメンバークラスのケースを検証するためのコントローラクラス。
+     */
+    public static class MemberController {
+        public static final Method ACTION_METHOD;
+
+        static {
+            try {
+                ACTION_METHOD = MemberController.class.getMethod("method");
+            } catch (Exception e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        public void method() {}
+    }
+}


### PR DESCRIPTION
上期に導入を見送ったHTTPリクエストの処理時間のメトリクスを収集するハンドラを追加する修正です。

## 仕様
- `MethodBinding` および `DispatchHandler` でリクエストスコープに保存したディスパッチ先のアクションクラス、メソッドの情報を `class`, `method` タグに出力する
- `class`, `method` のフォーマットは、 [Eclipse Microprofile の Metrics の仕様](https://download.eclipse.org/microprofile/microprofile-metrics-2.3/microprofile-metrics-spec-2.3.html#_optional_rest) を参考にしている
    - 型情報のフォーマットについては、Microprofile の実装の１つである Open Liberty の実際の動作結果を参考にしている
        -  `class` は `Class#getName()`
        - `method` の引数の型は `Class#getCanonicalName()`
- クラス・メソッドの情報がリクエストスコープから取得できない場合は、 `UNKNOWN` を設定する
- メトリクスに設定するタグを構築する処理はインタフェースで切り出して、必要であれば差し替え可能にしている