### PR TITLE
nablarch-parentに記載のJUnitのバージョンアップに伴いJUnitへの依存を削除。

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,13 +91,6 @@
       <artifactId>jmockit</artifactId>
       <scope>test</scope>
     </dependency>
-    
-    <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13</version>
-      <scope>test</scope>
-    </dependency>
 
     <dependency>
       <groupId>com.nablarch.framework</groupId>


### PR DESCRIPTION
* これまではnablarch-parentに記載のJUnitのバージョンが古かったため明記していたが、バージョンアップに伴い明記する必要がなくなった。
* 本対応はリリース不要。testスコープの依存の修正のみであるため。
