### PR TITLE
メトリクス拡充対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,5 +109,12 @@
       <artifactId>nablarch-test-support</artifactId>
       <scope>test</scope>
     </dependency>
+
+    <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-prometheus</artifactId>
+      <version>${version.micrometer}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,12 @@
 
     <dependency>
       <groupId>com.nablarch.framework</groupId>
+      <artifactId>nablarch-common-dao</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-fw-web</artifactId>
       <optional>true</optional>
     </dependency>

--- a/src/main/java/nablarch/integration/micrometer/DefaultMeterBinderListProvider.java
+++ b/src/main/java/nablarch/integration/micrometer/DefaultMeterBinderListProvider.java
@@ -31,8 +31,10 @@ import java.util.List;
  * @author Tanaka Tomoyuki
  */
 public class DefaultMeterBinderListProvider implements MeterBinderListProvider, Disposable {
+    /** ロガー。 */
     private static final Logger LOGGER = LoggerManager.get(DefaultMeterBinderListProvider.class);
 
+    /** 供給する {@link MeterBinder} のリスト。 */
     private final List<MeterBinder> meterBinderList;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/MeterRegistryFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/MeterRegistryFactory.java
@@ -45,6 +45,24 @@ public abstract class MeterRegistryFactory<T extends MeterRegistry> implements C
      */
     protected ApplicationDisposer applicationDisposer;
 
+    /**
+     * {@link ComponentFactory#createObject()} の実処理を行うメソッド。
+     * <p>
+     * サブクラスは、本メソッドを使って {@code createObject()} を次のように実装する。
+     * <pre><code>{@literal @}Override
+     * public SimpleMeterRegistry createObject() {
+     *     return doCreateObject();
+     * }</code></pre>
+     * </p>
+     * <p>
+     * これは、 {@code createObject()} の戻り値の型が総称型だった場合、
+     * DIコンテナがコンポーネントの具象型を特定できないことに起因する。<br>
+     * この問題は、上述のようにサブクラスで {@code createObject()} の戻り値の型を具象型として宣言することで回避できる。<br>
+     * 一方で、コンポーネントを作成するロジック自体はどの {@link MeterRegistry} でも共通なので、
+     * コンポーネント作成処理を共通化するために、このメソッドが用意されている。
+     * </p>
+     * @return 作成された {@link MeterRegistry} オブジェクト
+     */
     protected T doCreateObject() {
         if (meterBinderListProvider == null) {
             throw new IllegalStateException("MeterBinderListProvider is not set.");
@@ -64,6 +82,10 @@ public abstract class MeterRegistryFactory<T extends MeterRegistry> implements C
         return meterRegistry;
     }
 
+    /**
+     * {@link MicrometerConfiguration} を生成する。
+     * @return 生成された {@link MicrometerConfiguration}
+     */
     private MicrometerConfiguration createMicrometerConfiguration() {
         if (xmlConfigPath == null) {
             return new MicrometerConfiguration();
@@ -72,6 +94,10 @@ public abstract class MeterRegistryFactory<T extends MeterRegistry> implements C
         }
     }
 
+    /**
+     * 全てのメトリクスに共通して設定するタグをセットアップする。
+     * @param meterRegistry 設定対象の {@link MeterRegistry}
+     */
     private void setupCommonTags(MeterRegistry meterRegistry) {
         List<Tag> commonTagList = tags.entrySet()
                 .stream()

--- a/src/main/java/nablarch/integration/micrometer/MicrometerConfiguration.java
+++ b/src/main/java/nablarch/integration/micrometer/MicrometerConfiguration.java
@@ -31,6 +31,7 @@ import java.util.List;
  * @author Tanaka Tomoyuki
  */
 public class MicrometerConfiguration extends DiContainer {
+    /** デフォルトでDIコンテナを使用して読み込む設定ファイルのパス。 */
     private static final String DEFAULT_CONFIG_PATH = "nablarch/integration/micrometer/micrometer.xml";
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/NablarchMeterRegistryConfig.java
+++ b/src/main/java/nablarch/integration/micrometer/NablarchMeterRegistryConfig.java
@@ -8,7 +8,9 @@ import nablarch.core.repository.di.DiContainer;
  * @author Tanaka Tomoyuki
  */
 public abstract class NablarchMeterRegistryConfig implements MeterRegistryConfig {
+    /** 設定名のプレフィックス。 */
     private final String prefix;
+    /** 設定値の取得で使用する {@link DiContainer}。 */
     private final DiContainer diContainer;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/cloudwatch/CloudWatchMeterRegistryFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/cloudwatch/CloudWatchMeterRegistryFactory.java
@@ -12,6 +12,7 @@ import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
  */
 public class CloudWatchMeterRegistryFactory extends MeterRegistryFactory<CloudWatchMeterRegistry> {
 
+    /** {@link CloudWatchAsyncClientProvider}。 */
     private CloudWatchAsyncClientProvider cloudWatchAsyncClientProvider = CloudWatchAsyncClient::create;
 
     @Override

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchActionClassTagUtil.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchActionClassTagUtil.java
@@ -21,5 +21,8 @@ public final class BatchActionClassTagUtil {
         return Tag.of("class", tokens[0]);
     }
 
+    /**
+     * 本クラスはインスタンスを生成しない。
+     */
     private BatchActionClassTagUtil() {}
 }

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessTimeMetricsMetaDataBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessTimeMetricsMetaDataBuilder.java
@@ -25,17 +25,14 @@ import java.util.Objects;
  * @author Tanaka Tomoyuki
  */
 public class BatchProcessTimeMetricsMetaDataBuilder implements HandlerMetricsMetaDataBuilder<CommandLine, Object> {
-    /**
-     * デフォルトのメトリクス名。
-     */
+    /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "batch.process.time";
-
-    /**
-     * デフォルトのメトリクスの説明。
-     */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Batch process time.";
 
+    /** メトリクス名。 */
     private String metricsName = DEFAULT_METRICS_NAME;
+    /** メトリクスの説明。 */
     private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
 
     @Override

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
@@ -19,17 +19,16 @@ import nablarch.core.log.app.CommitLogger;
  * @author Tanaka Tomoyuki
  */
 public class BatchProcessedRecordCountMetricsLogger implements CommitLogger {
-    /**
-     * メトリクス名のデフォルト値。
-     */
+    /** メトリクス名のデフォルト値。 */
     static final String DEFAULT_METRICS_NAME = "batch.processed.record.count";
-    /**
-     * メトリクスの説明のデフォルト値。
-     */
+    /** メトリクスの説明のデフォルト値。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Count of processed records.";
 
+    /** 使用する {@link MeterRegistry}。 */
     private MeterRegistry meterRegistry;
+    /** メトリクス名。 */
     private String metricsName = DEFAULT_METRICS_NAME;
+    /** メトリクスの説明。 */
     private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
 
     @Override

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
@@ -19,9 +19,9 @@ import nablarch.core.log.app.CommitLogger;
  * @author Tanaka Tomoyuki
  */
 public class BatchProcessedRecordCountMetricsLogger implements CommitLogger {
-    /** メトリクス名のデフォルト値。 */
+    /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "batch.processed.record.count";
-    /** メトリクスの説明のデフォルト値。 */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Count of processed records.";
 
     /** 使用する {@link MeterRegistry}。 */

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
@@ -1,0 +1,84 @@
+package nablarch.integration.micrometer.instrument.batch;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import nablarch.core.ThreadContext;
+import nablarch.core.log.app.CommitLogger;
+
+import java.util.Collections;
+
+/**
+ * バッチの処理件数をメトリクスとして収集する{@link CommitLogger}の実装クラス。
+ * <p>
+ * メトリクスは、{@code "batch.processed.record.count"}という名前で作成される。<br>
+ * また、以下のタグが設定される。
+ * <ul>
+ *   <li>{@code class} : バッチのアクションクラス名</li>
+ * </ul>
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class BatchProcessedRecordCountMetricsLogger implements CommitLogger {
+    /**
+     * メトリクス名のデフォルト値。
+     */
+    static final String DEFAULT_METRICS_NAME = "batch.processed.record.count";
+    /**
+     * メトリクスの説明のデフォルト値。
+     */
+    static final String DEFAULT_METRICS_DESCRIPTION = "Count of processed records.";
+
+    private MeterRegistry meterRegistry;
+    private String metricsName = DEFAULT_METRICS_NAME;
+    private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
+
+    @Override
+    public void increment(long count) {
+        if (meterRegistry == null) {
+            throw new IllegalStateException("meterRegistry is null.");
+        }
+
+        Tag tag = BatchActionClassTagUtil.obtain(ThreadContext.getRequestId());
+
+        Counter.builder(metricsName)
+                .tags(Collections.singleton(tag))
+                .description(metricsDescription)
+                .register(meterRegistry)
+                .increment(count);
+    }
+
+    @Override
+    public void initialize() {
+        // noop
+    }
+
+    @Override
+    public void terminate() {
+        // noop
+    }
+
+    /**
+     * メトリクス名を設定する。
+     * @param metricsName メトリクス名
+     */
+    public void setMetricsName(String metricsName) {
+        this.metricsName = metricsName;
+    }
+
+    /**
+     * メトリクスの説明を設定する。
+     * @param metricsDescription メトリクスの説明
+     */
+    public void setMetricsDescription(String metricsDescription) {
+        this.metricsDescription = metricsDescription;
+    }
+
+    /**
+     * {@link MeterRegistry}を設定する。
+     * @param meterRegistry {@link MeterRegistry}
+     */
+    public void setMeterRegistry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java
@@ -3,10 +3,9 @@ package nablarch.integration.micrometer.instrument.batch;
 import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import nablarch.core.ThreadContext;
 import nablarch.core.log.app.CommitLogger;
-
-import java.util.Collections;
 
 /**
  * バッチの処理件数をメトリクスとして収集する{@link CommitLogger}の実装クラス。
@@ -42,7 +41,7 @@ public class BatchProcessedRecordCountMetricsLogger implements CommitLogger {
         Tag tag = BatchActionClassTagUtil.obtain(ThreadContext.getRequestId());
 
         Counter.builder(metricsName)
-                .tags(Collections.singleton(tag))
+                .tags(Tags.of(tag))
                 .description(metricsDescription)
                 .register(meterRegistry)
                 .increment(count);

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
@@ -18,20 +18,19 @@ import java.util.Collections;
  * @author Tanaka Tomoyuki
  */
 public class BatchTransactionTimeMetricsLogger implements CommitLogger {
+    /** {@link Timer} を {@link ThreadContext} に保存するときに使用するキー。 */
     private static final String THREAD_CONTEXT_KEY_TIMER_SAMPLE = "nablarch_transaction_timer_sample";
 
-    /**
-     * デフォルトのメトリクス名。
-     */
+    /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "batch.transaction.time";
-
-    /**
-     * デフォルトのメトリクスの説明。
-     */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Batch transaction time.";
 
+    /** 使用する {@link MeterRegistry}。 */
     private MeterRegistry meterRegistry;
+    /** メトリクス名。 */
     private String metricsName = DEFAULT_METRICS_NAME;
+    /** メトリクスの説明。 */
     private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
 
     @Override
@@ -50,6 +49,9 @@ public class BatchTransactionTimeMetricsLogger implements CommitLogger {
         beginTimer();
     }
 
+    /**
+     * {@link Timer} を起動し、 {@link ThreadContext} に {@link Timer} を保存する。
+     */
     private void beginTimer() {
         Timer.Sample sample = Timer.start(meterRegistry);
         ThreadContext.setObject(THREAD_CONTEXT_KEY_TIMER_SAMPLE, sample);

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
@@ -2,6 +2,7 @@ package nablarch.integration.micrometer.instrument.batch;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.Timer;
 import nablarch.core.ThreadContext;
 import nablarch.core.log.app.CommitLogger;
@@ -44,7 +45,7 @@ public class BatchTransactionTimeMetricsLogger implements CommitLogger {
         Tag batchClass = BatchActionClassTagUtil.obtain(ThreadContext.getRequestId());
         sample.stop(meterRegistry, Timer.builder(metricsName)
                 .description(metricsDescription)
-                .tags(Collections.singleton(batchClass)));
+                .tags(Tags.of(batchClass)));
 
         beginTimer();
     }

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
@@ -10,8 +10,11 @@ import java.util.Collections;
  * @author Tanaka Tomoyuki
  */
 public class MetricsMetaData {
+    /** メトリクス名。 */
     private final String name;
+    /** メトリクスの説明。 */
     private final String description;
+    /** タグの一覧。 */
     private final Iterable<Tag> tags;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
@@ -1,0 +1,61 @@
+package nablarch.integration.micrometer.instrument.binder;
+
+import io.micrometer.core.instrument.Tag;
+
+import java.util.Collections;
+
+/**
+ * メトリクスに設定する情報（名前、説明、タグ）を保持するデータクラス。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class MetricsMetaData {
+    private final String name;
+    private final String description;
+    private final Iterable<Tag> tags;
+
+    /**
+     * 名前、説明、タグ一覧を指定するコンストラクタ。
+     * @param name メトリクスの名前
+     * @param description メトリクスの説明
+     * @param tags メトリクスに設定するタグ一覧
+     */
+    public MetricsMetaData(String name, String description, Iterable<Tag> tags) {
+        this.name = name;
+        this.description = description;
+        this.tags = tags;
+    }
+
+    /**
+     * 名前、説明を指定するコンストラクタ。
+     * @param name メトリクスの名前
+     * @param description メトリクスの説明
+     */
+    public MetricsMetaData(String name, String description) {
+        this(name, description, Collections.emptyList());
+    }
+
+    /**
+     * メトリクスの名前を取得する。
+     * @return メトリクスの名前
+     */
+    public String getName() {
+        return name;
+    }
+
+    /**
+     * メトリクスの説明を取得する。
+     * @return メトリクスの説明
+     */
+    public String getDescription() {
+        return description;
+    }
+
+    /**
+     * タグ一覧を取得する。
+     * @return タグ一覧
+     */
+    public Iterable<Tag> getTags() {
+        return tags;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
@@ -16,9 +16,16 @@ import java.lang.management.ManagementFactory;
  * @author Tanaka Tomoyuki
  */
 public class JmxGaugeMetrics implements MeterBinder {
+    /** メトリクスのメタ情報。 */
     private final MetricsMetaData metricsMetaData;
+    /** 対象のMBeanを特定するための条件。 */
     private final MBeanAttributeCondition condition;
 
+    /**
+     * コンストラクタ。
+     * @param metricsMetaData メトリクスのメタ情報
+     * @param condition 対象のMBeanを特定するための条件
+     */
     public JmxGaugeMetrics(MetricsMetaData metricsMetaData, MBeanAttributeCondition condition) {
         this.metricsMetaData = metricsMetaData;
         this.condition = condition;
@@ -32,6 +39,13 @@ public class JmxGaugeMetrics implements MeterBinder {
             .register(registry);
     }
 
+    /**
+     * {@link Gauge} に設定する値をMBeanから取得する。
+     * <p>
+     * MBeanが取得できない場合、または取得した値が{@link Number}でない場合は {@code NaN} を返す。
+     * </p>
+     * @return MBeanから取得した値
+     */
     private double obtainGaugeValue() {
         try {
             MBeanServer server = ManagementFactory.getPlatformMBeanServer();

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
@@ -1,0 +1,48 @@
+package nablarch.integration.micrometer.instrument.binder.jmx;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+
+/**
+ * 指定したMBeanから定期的に値を取得し{@link Gauge}として記録する{@link MeterBinder}の実装クラス。
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class JmxGaugeMetrics implements MeterBinder {
+    private final MetricsMetaData metricsMetaData;
+    private final MBeanAttributeCondition condition;
+
+    public JmxGaugeMetrics(MetricsMetaData metricsMetaData, MBeanAttributeCondition condition) {
+        this.metricsMetaData = metricsMetaData;
+        this.condition = condition;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        Gauge.builder(metricsMetaData.getName(), this::obtainGaugeValue)
+            .description(metricsMetaData.getDescription())
+            .tags(metricsMetaData.getTags())
+            .register(registry);
+    }
+
+    private double obtainGaugeValue() {
+        try {
+            MBeanServer server = ManagementFactory.getPlatformMBeanServer();
+            Object value = server.getAttribute(new ObjectName(this.condition.getObjectName()), condition.getAttribute());
+            if (value instanceof Number) {
+                return ((Number) value).doubleValue();
+            } else {
+                return Double.NaN;
+            }
+        } catch (JMException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
@@ -5,7 +5,9 @@ package nablarch.integration.micrometer.instrument.binder.jmx;
  * @author Tanaka Tomoyuki
  */
 public class MBeanAttributeCondition {
+    /** オブジェクト名。 */
     private final String objectName;
+    /** 属性名。 */
     private final String attribute;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
@@ -1,0 +1,36 @@
+package nablarch.integration.micrometer.instrument.binder.jmx;
+
+/**
+ * JMXで取得するMBeanのAttributeを特定するための、オブジェクト名と属性名を保持したデータクラス。
+ * @author Tanaka Tomoyuki
+ */
+public class MBeanAttributeCondition {
+    private final String objectName;
+    private final String attribute;
+
+    /**
+     * オブジェクト名と属性を指定するコンストラクタ。
+     * @param objectName オブジェクト名
+     * @param attribute 属性名
+     */
+    public MBeanAttributeCondition(String objectName, String attribute) {
+        this.objectName = objectName;
+        this.attribute = attribute;
+    }
+
+    /**
+     * オブジェクト名を取得する。
+     * @return オブジェクト名
+     */
+    public String getObjectName() {
+        return objectName;
+    }
+
+    /**
+     * 属性名を取得する。
+     * @return 属性名
+     */
+    public String getAttribute() {
+        return attribute;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
@@ -20,18 +20,16 @@ import java.util.List;
  * @author Tanaka Tomoyuki
  */
 public class NablarchGcCountMetrics implements MeterBinder {
-    /**
-     * デフォルトのメトリクス名。
-     */
+    /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "jvm.gc.count";
-
-    /**
-     * デフォルトのメトリクスの説明。
-     */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Count of garbage collection";
 
+    /** 追加のタグ一覧。 */
     private final Iterable<Tag> tags;
+    /** メトリクス名。 */
     private final String metricsName;
+    /** メトリクスの説明。 */
     private final String metricsDescription;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
@@ -55,6 +56,16 @@ public class NablarchGcCountMetrics implements MeterBinder {
      */
     public NablarchGcCountMetrics(Iterable<Tag> tags) {
         this(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION, tags);
+    }
+
+    /**
+     * メトリクス名と説明、追加のタグを{@link MetricsMetaData}で指定するコンストラクタ。
+     * @param metricsMetaData メトリクスの設定情報
+     */
+    public NablarchGcCountMetrics(MetricsMetaData metricsMetaData) {
+        this.metricsName = metricsMetaData.getName();
+        this.metricsDescription = metricsMetaData.getDescription();
+        this.tags = metricsMetaData.getTags();
     }
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import nablarch.core.log.basic.LogLevel;
 import nablarch.core.log.basic.LogListener;
 import nablarch.core.log.basic.LogPublisher;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 
 import java.io.Closeable;
 
@@ -51,8 +52,7 @@ public class LogCountMetrics implements MeterBinder, Closeable {
     static final String TAG_NAME_RUNTIME_LOGGER = "logger";
 
     private final LogLevel logLevel;
-    private final String metricsName;
-    private final String metricsDescription;
+    private final MetricsMetaData metricsMetaData;
     private LogListener logListener;
 
     /**
@@ -70,27 +70,24 @@ public class LogCountMetrics implements MeterBinder, Closeable {
      * @param logLevel ログレベル
      */
     public LogCountMetrics(LogLevel logLevel) {
-        this(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION, logLevel);
+        this(new MetricsMetaData(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION), logLevel);
     }
 
     /**
-     * ログレベルを指定するコンストラクタ。
-     * @param metricsName メトリクス名
-     * @param metricsDescription メトリクスの説明
+     * メトリクスの設定情報を指定するコンストラクタ。
+     * @param metricsMetaData メトリクスの設定情報
      */
-    public LogCountMetrics(String metricsName, String metricsDescription) {
-        this(metricsName, metricsDescription, DEFAULT_LOG_LEVEL);
+    public LogCountMetrics(MetricsMetaData metricsMetaData) {
+        this(metricsMetaData, DEFAULT_LOG_LEVEL);
     }
 
     /**
      * ログレベルを指定するコンストラクタ。
-     * @param metricsName メトリクス名
-     * @param metricsDescription メトリクスの説明
+     * @param metricsMetaData メトリクスの設定情報
      * @param logLevel ログレベル
      */
-    public LogCountMetrics(String metricsName, String metricsDescription, LogLevel logLevel) {
-        this.metricsName = metricsName;
-        this.metricsDescription = metricsDescription;
+    public LogCountMetrics(MetricsMetaData metricsMetaData, LogLevel logLevel) {
+        this.metricsMetaData = metricsMetaData;
         this.logLevel = logLevel;
     }
 
@@ -101,10 +98,11 @@ public class LogCountMetrics implements MeterBinder, Closeable {
                 return;
             }
 
-            Counter.builder(metricsName)
+            Counter.builder(metricsMetaData.getName())
                     .tag(TAG_NAME_LEVEL, logContext.getLevel().name())
                     .tag(TAG_NAME_RUNTIME_LOGGER, logContext.getRuntimeLoggerName())
-                    .description(metricsDescription)
+                    .tags(metricsMetaData.getTags())
+                    .description(metricsMetaData.getDescription())
                     .register(registry)
                     .increment();
         };

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
@@ -1,0 +1,119 @@
+package nablarch.integration.micrometer.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.binder.MeterBinder;
+import nablarch.core.log.basic.LogLevel;
+import nablarch.core.log.basic.LogListener;
+import nablarch.core.log.basic.LogPublisher;
+
+import java.io.Closeable;
+
+/**
+ * ログレベルごとのログ出力回数をメトリクスとして収集する{@link MeterBinder}。
+ * <p>
+ * メトリクス名は{@code log.count}になる。<br>
+ * また、メトリクスのタグには以下の値が設定される。
+ * <ul>
+ *   <li>{@code level}: ログレベル</li>
+ *   <li>{@code logger}: 実行時ロガー名({@code LoggerManager.get(String)} の引数で渡した名前)</li>
+ * </ul>
+ * </p>
+ * <p>
+ * デフォルトでは{@code WARN}以上のログのみを集計する。<br>
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class LogCountMetrics implements MeterBinder, Closeable {
+    /**
+     * デフォルトのメトリクスの名前。
+     */
+    static final String DEFAULT_METRICS_NAME = "log.count";
+
+    /**
+     * デフォルトのメトリクスの説明。
+     */
+    static final String DEFAULT_METRICS_DESCRIPTION = "Logging count for each log level and runtime logger.";
+
+    /**
+     * デフォルトのログレベル。
+     */
+    private static final LogLevel DEFAULT_LOG_LEVEL = LogLevel.WARN;
+
+    /**
+     * ログレベルのタグ名。
+     */
+    static final String TAG_NAME_LEVEL = "level";
+
+    /**
+     * 実行時ロガー名のタグ名。
+     */
+    static final String TAG_NAME_RUNTIME_LOGGER = "logger";
+
+    private final LogLevel logLevel;
+    private final String metricsName;
+    private final String metricsDescription;
+    private LogListener logListener;
+
+    /**
+     * デフォルトコンストラクタ。
+     * <p>
+     * ログレベルは{@link LogLevel#WARN}になる。
+     * </p>
+     */
+    public LogCountMetrics() {
+        this(DEFAULT_LOG_LEVEL);
+    }
+
+    /**
+     * ログレベルを指定するコンストラクタ。
+     * @param logLevel ログレベル
+     */
+    public LogCountMetrics(LogLevel logLevel) {
+        this(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION, logLevel);
+    }
+
+    /**
+     * ログレベルを指定するコンストラクタ。
+     * @param metricsName メトリクス名
+     * @param metricsDescription メトリクスの説明
+     */
+    public LogCountMetrics(String metricsName, String metricsDescription) {
+        this(metricsName, metricsDescription, DEFAULT_LOG_LEVEL);
+    }
+
+    /**
+     * ログレベルを指定するコンストラクタ。
+     * @param metricsName メトリクス名
+     * @param metricsDescription メトリクスの説明
+     * @param logLevel ログレベル
+     */
+    public LogCountMetrics(String metricsName, String metricsDescription, LogLevel logLevel) {
+        this.metricsName = metricsName;
+        this.metricsDescription = metricsDescription;
+        this.logLevel = logLevel;
+    }
+
+    @Override
+    public void bindTo(MeterRegistry registry) {
+        logListener = logContext -> {
+            if (logLevel.getValue() < logContext.getLevel().getValue()) {
+                return;
+            }
+
+            Counter.builder(metricsName)
+                    .tag(TAG_NAME_LEVEL, logContext.getLevel().name())
+                    .tag(TAG_NAME_RUNTIME_LOGGER, logContext.getRuntimeLoggerName())
+                    .description(metricsDescription)
+                    .register(registry)
+                    .increment();
+        };
+
+        LogPublisher.addListener(logListener);
+    }
+
+    @Override
+    public void close() {
+        LogPublisher.removeListener(logListener);
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
@@ -51,7 +51,7 @@ public class LogCountMetrics implements MeterBinder, Closeable {
      */
     static final String TAG_NAME_RUNTIME_LOGGER = "logger";
 
-    private final LogLevel logLevel;
+    private final LogLevel thresholdOfLogLevel;
     private final MetricsMetaData metricsMetaData;
     private LogListener logListener;
 
@@ -66,11 +66,15 @@ public class LogCountMetrics implements MeterBinder, Closeable {
     }
 
     /**
-     * ログレベルを指定するコンストラクタ。
-     * @param logLevel ログレベル
+     * 収集するログレベルのしきい値を指定するコンストラクタ。
+     * <p>
+     * 指定されたログレベル以上のログ出力が計測の対象となる。
+     * </p>
+     *
+     * @param thresholdOfLogLevel ログレベルのしきい値
      */
-    public LogCountMetrics(LogLevel logLevel) {
-        this(new MetricsMetaData(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION), logLevel);
+    public LogCountMetrics(LogLevel thresholdOfLogLevel) {
+        this(new MetricsMetaData(DEFAULT_METRICS_NAME, DEFAULT_METRICS_DESCRIPTION), thresholdOfLogLevel);
     }
 
     /**
@@ -82,19 +86,23 @@ public class LogCountMetrics implements MeterBinder, Closeable {
     }
 
     /**
-     * ログレベルを指定するコンストラクタ。
+     * メトリクスの設定情報と、収集するログレベルのしきい値を指定するコンストラクタ。
+     * <p>
+     * 指定されたログレベル以上のログ出力が計測の対象となる。
+     * </p>
+     *
      * @param metricsMetaData メトリクスの設定情報
-     * @param logLevel ログレベル
+     * @param thresholdOfLogLevel ログレベルのしきい値
      */
-    public LogCountMetrics(MetricsMetaData metricsMetaData, LogLevel logLevel) {
+    public LogCountMetrics(MetricsMetaData metricsMetaData, LogLevel thresholdOfLogLevel) {
         this.metricsMetaData = metricsMetaData;
-        this.logLevel = logLevel;
+        this.thresholdOfLogLevel = thresholdOfLogLevel;
     }
 
     @Override
     public void bindTo(MeterRegistry registry) {
         logListener = logContext -> {
-            if (logLevel.getValue() < logContext.getLevel().getValue()) {
+            if (thresholdOfLogLevel.getValue() < logContext.getLevel().getValue()) {
                 return;
             }
 

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
@@ -26,33 +26,29 @@ import java.io.Closeable;
  * @author Tanaka Tomoyuki
  */
 public class LogCountMetrics implements MeterBinder, Closeable {
-    /**
-     * デフォルトのメトリクスの名前。
-     */
+    /** デフォルトのメトリクスの名前。 */
     static final String DEFAULT_METRICS_NAME = "log.count";
-
-    /**
-     * デフォルトのメトリクスの説明。
-     */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "Logging count for each log level and runtime logger.";
 
-    /**
-     * デフォルトのログレベル。
-     */
+    /** デフォルトのログレベル。 */
     private static final LogLevel DEFAULT_LOG_LEVEL = LogLevel.WARN;
-
-    /**
-     * ログレベルのタグ名。
-     */
+    /** ログレベルのタグ名。 */
     static final String TAG_NAME_LEVEL = "level";
-
-    /**
-     * 実行時ロガー名のタグ名。
-     */
+    /** 実行時ロガー名のタグ名。 */
     static final String TAG_NAME_RUNTIME_LOGGER = "logger";
 
+    /** 収集対象となるログレベルのしきい値。 */
     private final LogLevel thresholdOfLogLevel;
+    /** メトリクスのメタ情報。 */
     private final MetricsMetaData metricsMetaData;
+    /**
+     * {@link LogPublisher} に設定する {@link LogListener} のキャッシュ。
+     * <p>
+     * {@link #close()} のときに {@link LogPublisher#removeListener(LogListener)} で削除できるようにするため、
+     * フィールドで保持している。
+     * </p>
+     */
     private LogListener logListener;
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContext.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContext.java
@@ -1,0 +1,242 @@
+package nablarch.integration.micrometer.instrument.dao;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import nablarch.common.dao.DaoContext;
+import nablarch.common.dao.EntityList;
+
+import javax.persistence.OptimisticLockException;
+import java.util.List;
+import java.util.function.Supplier;
+
+/**
+ * SQLの処理実行時間をメトリクスとして計測する{@link DaoContext}のラッパークラス。
+ * <p>
+ * メトリクスは、{@code sql.process.time}という名前になる。
+ * </p>
+ * <p>
+ * また、メトリクスには以下のタグが設定される。
+ * <ul>
+ *   <li>{@code sql.id}: SQLID(無い場合は{@code "None"})</li>
+ *   <li>{@code entity}: エンティティクラスの名前({@link Class#getName()})。</li>
+ *   <li>{@code method}: 実行された{@link DaoContext}のメソッドの単純名</li>
+ * </ul>
+ * </p>
+ * <p>
+ * 引数で渡されたエンティティまたはエンティティのリストが、{@code null}または空のリストの場合は、
+ * 時間は計測されない（委譲先のメソッドの処理は実行される）。
+ * </p>
+ * @author Tanaka Tomoyuki
+ */
+public class SqlTimeMetricsDaoContext implements DaoContext {
+    /**
+     * デフォルトのメトリクス名。
+     */
+    static final String DEFAULT_METRICS_NAME = "sql.process.time";
+
+    /**
+     * デフォルトのメトリクスの説明。
+     */
+    static final String DEFAULT_METRICS_DESCRIPTION = "Time of processing sql.";
+
+    /**
+     * SQLIDのタグ名。
+     */
+    static final String TAG_NAME_SQL_ID = "sql.id";
+
+    /**
+     * エンティティ名のタグ名。
+     */
+    static final String TAG_NAME_ENTITY_NAME = "entity";
+
+    /**
+     * 実行されたメソッド名のタグ名。
+     */
+    static final String TAG_NAME_METHOD_NAME = "method";
+
+    /**
+     * SQLIDが無い場合に設定されるタグの値。
+     */
+    static final String TAG_VALUE_NO_SQL_ID = "None";
+
+    private final DaoContext delegate;
+    private final MeterRegistry meterRegistry;
+
+    private String metricsName = DEFAULT_METRICS_NAME;
+    private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
+
+    /**
+     * 委譲先の {@link DaoContext}と{@link MeterRegistry}を指定するコンストラクタ。
+     * @param delegate 委譲先の{@link DaoContext}
+     * @param meterRegistry {@link MeterRegistry}
+     */
+    public SqlTimeMetricsDaoContext(DaoContext delegate, MeterRegistry meterRegistry) {
+        this.delegate = delegate;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @Override
+    public <T> T findById(Class<T> entityClass, Object... id) {
+        return recordTime(TAG_VALUE_NO_SQL_ID, entityClass, "findById",
+                () -> delegate.findById(entityClass, id));
+    }
+
+    @Override
+    public <T> EntityList<T> findAll(Class<T> entityClass) {
+        return recordTime(TAG_VALUE_NO_SQL_ID, entityClass, "findAll",
+                () -> delegate.findAll(entityClass));
+    }
+
+    @Override
+    public <T> EntityList<T> findAllBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+        return recordTime(sqlId, entityClass, "findAllBySqlFile",
+                () -> delegate.findAllBySqlFile(entityClass, sqlId, params));
+    }
+
+    @Override
+    public <T> EntityList<T> findAllBySqlFile(Class<T> entityClass, String sqlId) {
+        return recordTime(sqlId, entityClass, "findAllBySqlFile",
+                () -> delegate.findAllBySqlFile(entityClass, sqlId));
+    }
+
+    @Override
+    public <T> T findBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+        return recordTime(sqlId, entityClass, "findBySqlFile",
+                () -> delegate.findBySqlFile(entityClass, sqlId, params));
+    }
+
+    @Override
+    public <T> long countBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+        return recordTime(sqlId, entityClass, "countBySqlFile",
+                () -> delegate.countBySqlFile(entityClass, sqlId, params));
+    }
+
+    @Override
+    public <T> int update(T entity) throws OptimisticLockException {
+        return recordEntityUpdate(entity, "update", () -> delegate.update(entity));
+    }
+
+    @Override
+    public <T> void batchUpdate(List<T> entities) {
+        recordEntityListUpdate(entities, "batchUpdate", () -> delegate.batchUpdate(entities));
+    }
+
+    @Override
+    public <T> void insert(T entity) {
+        recordEntityUpdate(entity, "insert", () -> {
+            delegate.insert(entity);
+            return null;
+        });
+    }
+
+    @Override
+    public <T> void batchInsert(List<T> entities) {
+        recordEntityListUpdate(entities, "batchInsert", () -> delegate.batchInsert(entities));
+    }
+
+    @Override
+    public <T> int delete(T entity) {
+        return recordEntityUpdate(entity, "delete", () -> delegate.delete(entity));
+    }
+
+    @Override
+    public <T> void batchDelete(List<T> entities) {
+        recordEntityListUpdate(entities, "batchDelete", () -> delegate.batchDelete(entities));
+    }
+
+    private void recordEntityListUpdate(List<?> entities, String methodName, Runnable execution) {
+        if (entities == null || entities.isEmpty()) {
+            execution.run();
+            return;
+        }
+
+        recordTime(TAG_VALUE_NO_SQL_ID, entities.get(0).getClass(), methodName, () -> {
+            execution.run();
+            return null;
+        });
+    }
+
+    private <T> T recordEntityUpdate(Object entity, String methodName, Supplier<T> execution) {
+        if (entity == null) {
+            return execution.get();
+        }
+
+        return recordTime(TAG_VALUE_NO_SQL_ID, entity.getClass(), methodName, execution);
+    }
+
+    private <T> T recordTime(String sqlId, Class<?> entityClass, String methodName, Supplier<T> execution) {
+        return Timer.builder(metricsName)
+                    .description(metricsDescription)
+                    .tag(TAG_NAME_SQL_ID, sqlId)
+                    .tag(TAG_NAME_ENTITY_NAME, entityClass.getName())
+                    .tag(TAG_NAME_METHOD_NAME, methodName)
+                    .register(meterRegistry)
+                    .record(execution);
+    }
+
+    @Override
+    public DaoContext page(long page) {
+        delegate.page(page);
+        return this;
+    }
+
+    @Override
+    public DaoContext per(long per) {
+        delegate.per(per);
+        return this;
+    }
+
+    @Override
+    public DaoContext defer() {
+        delegate.defer();
+        return this;
+    }
+
+    /**
+     * メトリクスの名前を設定する。
+     * @param metricsName メトリクスの名前
+     */
+    public void setMetricsName(String metricsName) {
+        this.metricsName = metricsName;
+    }
+
+    /**
+     * メトリクス名を取得する。
+     * @return メトリクス名
+     */
+    public String getMetricsName() {
+        return metricsName;
+    }
+
+    /**
+     * メトリクスの説明を設定する。
+     * @param metricsDescription メトリクスの説明
+     */
+    public void setMetricsDescription(String metricsDescription) {
+        this.metricsDescription = metricsDescription;
+    }
+
+    /**
+     * メトリクスの説明を取得する。
+     * @return メトリクスの説明
+     */
+    public String getMetricsDescription() {
+        return metricsDescription;
+    }
+
+    /**
+     * 委譲先の{@link DaoContext}を取得する。
+     * @return 委譲先の {@link DaoContext}
+     */
+    public DaoContext getDelegate() {
+        return delegate;
+    }
+
+    /**
+     * {@link MeterRegistry}を取得する。
+     * @return {@link MeterRegistry}
+     */
+    public MeterRegistry getMeterRegistry() {
+        return meterRegistry;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactory.java
@@ -10,11 +10,13 @@ import nablarch.common.dao.DaoContextFactory;
  * @author Tanaka Tomoyuki
  */
 public class SqlTimeMetricsDaoContextFactory extends DaoContextFactory {
-
+    /** 移譲先の{@link DaoContextFactory}。 */
     private DaoContextFactory delegate;
+    /** 使用する{@link MeterRegistry}。 */
     private MeterRegistry meterRegistry;
-
+    /** メトリクス名。 */
     private String metricsName;
+    /** メトリクスの説明。 */
     private String metricsDescription;
 
     @Override

--- a/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactory.java
@@ -1,0 +1,72 @@
+package nablarch.integration.micrometer.instrument.dao;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import nablarch.common.dao.DaoContext;
+import nablarch.common.dao.DaoContextFactory;
+
+/**
+ * 委譲対象({@code delegate})の{@link DaoContextFactory}が生成する{@link DaoContext}をラップした
+ * {@link SqlTimeMetricsDaoContext}を生成するファクトリクラス。
+ * @author Tanaka Tomoyuki
+ */
+public class SqlTimeMetricsDaoContextFactory extends DaoContextFactory {
+
+    private DaoContextFactory delegate;
+    private MeterRegistry meterRegistry;
+
+    private String metricsName;
+    private String metricsDescription;
+
+    @Override
+    public DaoContext create() {
+        if (delegate == null) {
+            throw new IllegalStateException("delegate is null.");
+        }
+        if (meterRegistry == null) {
+            throw new IllegalStateException("meterRegistry is null.");
+        }
+
+        SqlTimeMetricsDaoContext daoContext = new SqlTimeMetricsDaoContext(delegate.create(), meterRegistry);
+
+        if (metricsName != null) {
+            daoContext.setMetricsName(metricsName);
+        }
+        if (metricsDescription != null) {
+            daoContext.setMetricsDescription(metricsDescription);
+        }
+
+        return daoContext;
+    }
+
+    /**
+     * 委譲対象の{@link DaoContextFactory}を設定する。
+     * @param delegate 委譲対象の{@link DaoContextFactory}
+     */
+    public void setDelegate(DaoContextFactory delegate) {
+        this.delegate = delegate;
+    }
+
+    /**
+     * {@link MeterRegistry}を設定する。
+     * @param meterRegistry {@link MeterRegistry}
+     */
+    public void setMeterRegistry(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    /**
+     * {@link SqlTimeMetricsDaoContext}に設定するメトリクス名を指定する。
+     * @param metricsName メトリクス名
+     */
+    public void setMetricsName(String metricsName) {
+        this.metricsName = metricsName;
+    }
+
+    /**
+     * {@link SqlTimeMetricsDaoContext}に設定するメトリクスの説明を指定する。
+     * @param metricsDescription メトリクスの説明
+     */
+    public void setMetricsDescription(String metricsDescription) {
+        this.metricsDescription = metricsDescription;
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
@@ -17,13 +17,20 @@ import java.util.stream.Collectors;
  * @author Tanaka Tomoyuki
  */
 public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResult> {
+    /** 使用する{@link MeterRegistry}。 */
     private MeterRegistry meterRegistry;
+    /** {@link HandlerMetricsMetaDataBuilder}。 */
     private HandlerMetricsMetaDataBuilder<TData, TResult> handlerMetricsMetaDataBuilder;
 
+    /** 収集対象のパーセンタイル。 */
     private double[] percentiles;
+    /** ヒストグラムバケットの連携の有効・無効フラグ。 */
     private boolean enablePercentileHistogram;
+    /** SLOに基づく追加のバケット。 */
     private Duration[] serviceLevelObjectives;
+    /** バケットの最小値。 */
     private Long minimumExpectedValue;
+    /** バケットの最大値。 */
     private Long maximumExpectedValue;
 
     @Override
@@ -61,6 +68,10 @@ public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResu
         }
     }
 
+    /**
+     * パーセンタイルについての設定を行う。
+     * @param builder 設定対象の{@link io.micrometer.core.instrument.Timer.Builder}
+     */
     private void setupPercentileOptions(Timer.Builder builder) {
         builder.publishPercentileHistogram(enablePercentileHistogram);
 

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
@@ -20,9 +20,9 @@ public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResu
     private MeterRegistry meterRegistry;
     private HandlerMetricsMetaDataBuilder<TData, TResult> handlerMetricsMetaDataBuilder;
 
-    private List<String> percentiles;
+    private double[] percentiles;
     private boolean enablePercentileHistogram;
-    private List<String> serviceLevelObjectives;
+    private Duration[] serviceLevelObjectives;
     private Long minimumExpectedValue;
     private Long maximumExpectedValue;
 
@@ -65,15 +65,10 @@ public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResu
         builder.publishPercentileHistogram(enablePercentileHistogram);
 
         if (percentiles != null) {
-            double[] percentileArray = percentiles.stream().mapToDouble(Double::parseDouble).toArray();
-            builder.publishPercentiles(percentileArray);
+            builder.publishPercentiles(percentiles);
         }
         if (serviceLevelObjectives != null) {
-            Duration[] sloArray = serviceLevelObjectives.stream()
-                    .map(Long::parseLong)
-                    .map(Duration::ofMillis)
-                    .toArray(Duration[]::new);
-            builder.serviceLevelObjectives(sloArray);
+            builder.serviceLevelObjectives(serviceLevelObjectives);
         }
         if (minimumExpectedValue != null) {
             builder.minimumExpectedValue(Duration.ofMillis(minimumExpectedValue));
@@ -115,7 +110,7 @@ public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResu
      * @param percentiles 追加するパーセンタイルのリスト
      */
     public void setPercentiles(List<String> percentiles) {
-        this.percentiles = percentiles;
+        this.percentiles = percentiles.stream().mapToDouble(Double::parseDouble).toArray();
     }
 
     /**
@@ -142,7 +137,10 @@ public class TimerMetricsHandler<TData, TResult> implements Handler<TData, TResu
      * @param serviceLevelObjectives サービスレベル目標のリスト
      */
     public void setServiceLevelObjectives(List<String> serviceLevelObjectives) {
-        this.serviceLevelObjectives = serviceLevelObjectives;
+        this.serviceLevelObjectives = serviceLevelObjectives.stream()
+                                        .map(Long::parseLong)
+                                        .map(Duration::ofMillis)
+                                        .toArray(Duration[]::new);;
     }
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilder.java
@@ -65,17 +65,14 @@ import java.util.List;
  * @author Tanaka Tomoyuki
  */
 public class HttpRequestTimeMetricsMetaDataBuilder implements HandlerMetricsMetaDataBuilder<HttpRequest, Object> {
-    /**
-     * デフォルトのメトリクス名。
-     */
+    /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "http.server.requests";
-
-    /**
-     * デフォルトのメトリクスの説明。
-     */
+    /** デフォルトのメトリクスの説明。 */
     static final String DEFAULT_METRICS_DESCRIPTION = "HTTP request metrics measured by Timer.";
 
+    /** メトリクス名。 */
     private String metricsName = DEFAULT_METRICS_NAME;
+    /** メトリクスの説明。 */
     private String metricsDescription = DEFAULT_METRICS_DESCRIPTION;
 
     @Override
@@ -109,6 +106,11 @@ public class HttpRequestTimeMetricsMetaDataBuilder implements HandlerMetricsMeta
         );
     }
 
+    /**
+     * {@code method} タグに設定する値を構築する。
+     * @param method 実行されたメソッド
+     * @return {@code method} タグに設定する値
+     */
     private String buildMethodTag(Method method) {
         StringBuilder sb = new StringBuilder(method.getName());
 
@@ -119,6 +121,11 @@ public class HttpRequestTimeMetricsMetaDataBuilder implements HandlerMetricsMeta
         return sb.toString();
     }
 
+    /**
+     * {@code outcome} タグに設定する値を解決する。
+     * @param statusCode レスポンスのステータスコード
+     * @return {@code outcome} タグに設定する値
+     */
     private String resolveOutcome(int statusCode) {
         if (100 <= statusCode && statusCode < 200) {
             return "INFORMATION";
@@ -135,6 +142,12 @@ public class HttpRequestTimeMetricsMetaDataBuilder implements HandlerMetricsMeta
         }
     }
 
+    /**
+     * {@code exception} タグに設定する値を解決する。
+     * @param context 実行コンテキスト
+     * @param thrownThrowable スローされた例外
+     * @return {@code exception} タグに設定する値
+     */
     private String resolveException(ExecutionContext context, Throwable thrownThrowable) {
         Throwable throwable = thrownThrowable != null ? thrownThrowable : context.getException();
         return throwable == null ? "None" : throwable.getClass().getSimpleName();

--- a/src/test/java/nablarch/integration/micrometer/MockJulHandler.java
+++ b/src/test/java/nablarch/integration/micrometer/MockJulHandler.java
@@ -1,0 +1,45 @@
+package nablarch.integration.micrometer;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Handler;
+import java.util.logging.LogRecord;
+
+/**
+ * Micrometerが内部で出力したログ出力を収集してテストできるようにするためのハンドラ。
+ * <p>
+ * 以下のようにルートロガーに追加することで、JULに出力されたログの情報が収集できるようになる。
+ * <pre>{@code
+ * Logger rootLogger = Logger.getLogger("");
+ * MockJulHandler mockJulHandler = new MockJulHandler();
+ * rootLogger.addHandler(mockJulHandler);
+ * ...
+ * rootLogger.removeHandler(mockJulHandler); // teardown などで削除する
+ * }</pre>
+ * </p>
+ * <p>
+ * 収集されたログの情報は、{@link #getPublishedRecordList()}で取得できる。
+ * </p>
+ *
+ * @author Tanaka Tomoyuki
+ */
+public class MockJulHandler extends Handler {
+    private List<LogRecord> publishedRecordList = new ArrayList<>();
+
+    @Override
+    public void publish(LogRecord record) {
+        publishedRecordList.add(record);
+    }
+
+    /**
+     * 出力された{@link LogRecord}のリストを取得する。
+     * @return 出力された{@link LogRecord}のリスト
+     */
+    public List<LogRecord> getPublishedRecordList() {
+        return publishedRecordList;
+    }
+
+    @Override public void flush() {}
+
+    @Override public void close() throws SecurityException {}
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/MetricsMetaDataTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/MetricsMetaDataTest.java
@@ -1,0 +1,36 @@
+package nablarch.integration.micrometer.instrument;
+
+import io.micrometer.core.instrument.Tag;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
+import org.junit.Test;
+
+import java.util.Arrays;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link MetricsMetaData}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class MetricsMetaDataTest {
+
+    @Test
+    public void testConstructorWithTags() {
+        MetricsMetaData sut = new MetricsMetaData(
+                "name", "description", Arrays.asList(Tag.of("foo", "FOO"), Tag.of("bar", "BAR")));
+
+        assertThat(sut.getName(), is("name"));
+        assertThat(sut.getDescription(), is("description"));
+        assertThat(sut.getTags(), containsInAnyOrder(Tag.of("foo", "FOO"), Tag.of("bar", "BAR")));
+    }
+
+    @Test
+    public void testConstructorWithoutTags() {
+        MetricsMetaData sut = new MetricsMetaData("NAME", "DESCRIPTION");
+
+        assertThat(sut.getName(), is("NAME"));
+        assertThat(sut.getDescription(), is("DESCRIPTION"));
+        assertThat(sut.getTags(), is(emptyIterable()));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLoggerTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLoggerTest.java
@@ -1,0 +1,81 @@
+package nablarch.integration.micrometer.instrument.batch;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import nablarch.core.ThreadContext;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * {@link BatchProcessedRecordCountMetricsLogger}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class BatchProcessedRecordCountMetricsLoggerTest {
+    private final BatchProcessedRecordCountMetricsLogger sut = new BatchProcessedRecordCountMetricsLogger();
+    private final SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry();
+    private String originalRequestId;
+
+    @Before
+    public void setUp() {
+        originalRequestId = ThreadContext.getRequestId();
+        ThreadContext.setRequestId("TestAction/test");
+        sut.setMeterRegistry(meterRegistry);
+    }
+
+    @Test
+    public void testIncrement() {
+        sut.increment(3L);
+
+        Counter counter = meterRegistry.find(BatchProcessedRecordCountMetricsLogger.DEFAULT_METRICS_NAME).counter();
+        assertThat(counter.count(), is(3.0));
+        assertThat(counter.getId().getDescription(), is(BatchProcessedRecordCountMetricsLogger.DEFAULT_METRICS_DESCRIPTION));
+        assertThat(counter.getId().getTag("class"), is("TestAction"));
+    }
+
+    @Test
+    public void testSetMetricsName() {
+        sut.setMetricsName("test.metrics");
+        sut.increment(2L);
+
+        Counter counter = meterRegistry.find("test.metrics").counter();
+        assertThat(counter.count(), is(2.0));
+    }
+
+    @Test
+    public void testSetMetricsDescription() {
+        sut.setMetricsDescription("Test metrics.");
+        sut.increment(2L);
+
+        Counter counter = meterRegistry.find(BatchProcessedRecordCountMetricsLogger.DEFAULT_METRICS_NAME).counter();
+        assertThat(counter.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testThrowExceptionIfMeterRegistryIsNull() {
+        sut.setMeterRegistry(null);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, () -> sut.increment(1L));
+
+        assertThat(exception.getMessage(), is("meterRegistry is null."));
+    }
+
+    @Test
+    public void testNoopMethods() {
+        /*
+         * カバレッジを通すため、何もしないメソッドを実行するテストを走らせている。
+         * ひとまず、例外がスローされないことだけを確認。
+         */
+        sut.initialize();
+        sut.terminate();
+    }
+
+    @After
+    public void tearDown() {
+        ThreadContext.setRequestId(originalRequestId);
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetricsTest.java
@@ -1,0 +1,125 @@
+package nablarch.integration.micrometer.instrument.binder.jmx;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.integration.micrometer.MockJulHandler;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.management.JMException;
+import javax.management.MBeanServer;
+import javax.management.ObjectName;
+import java.lang.management.ManagementFactory;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.LogRecord;
+import java.util.logging.Logger;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link JmxGaugeMetrics}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class JmxGaugeMetricsTest {
+    @Mocked
+    private ManagementFactory managementFactory;
+    @Mocked
+    private MBeanServer mBeanServer;
+
+    private ObjectName objectName;
+    private String attributeName;
+    private MBeanAttributeCondition mBeanAttributeCondition;
+    private MetricsMetaData metricsMetaData;
+    private SimpleMeterRegistry meterRegistry;
+
+    private JmxGaugeMetrics sut;
+
+    private MockJulHandler mockJulHandler;
+
+    @Before
+    public void setUp() throws Exception {
+        Logger logger = Logger.getLogger("");
+        mockJulHandler = new MockJulHandler();
+        logger.addHandler(mockJulHandler);
+
+        new Expectations() {{
+            ManagementFactory.getPlatformMBeanServer(); result = mBeanServer;
+        }};
+
+        attributeName = "ATTRIBUTE";
+        objectName = new ObjectName("test:type=Foo");
+        mBeanAttributeCondition =
+                new MBeanAttributeCondition(objectName.getCanonicalName(), attributeName);
+
+        metricsMetaData = new MetricsMetaData(
+                "metrics.name", "Metrics Description", Arrays.asList(Tag.of("foo", "FOO"), Tag.of("bar", "BAR")));
+
+        sut = new JmxGaugeMetrics(metricsMetaData, mBeanAttributeCondition);
+
+        meterRegistry = new SimpleMeterRegistry();
+        sut.bindTo(meterRegistry);
+    }
+
+    @Test
+    public void testMeasureGaugeValueFromSpecifiedMBeanAttribute() throws Exception {
+        new Expectations() {{
+            mBeanServer.getAttribute(objectName, attributeName); result = 12.34;
+        }};
+
+        Gauge gauge = meterRegistry.find(metricsMetaData.getName()).gauge();
+
+        Meter.Id id = gauge.getId();
+
+        assertThat(id.getDescription(), is(metricsMetaData.getDescription()));
+        assertThat(id.getTags(), containsInAnyOrder(toArray(metricsMetaData.getTags())));
+        assertThat(gauge.value(), is(12.34));
+    }
+
+    @Test
+    public void testMeasureGaugeValueAsNaNIfAttributeValueIsNotNumber() throws Exception {
+        new Expectations() {{
+            mBeanServer.getAttribute(objectName, attributeName); result = "NotNumber";
+        }};
+
+        Gauge gauge = meterRegistry.find(metricsMetaData.getName()).gauge();
+
+        assertThat(gauge.value(), is(Double.NaN));
+    }
+
+    @Test
+    public void testWarnLogIfJMExceptionIsThrown() throws Exception {
+        // Gaugeの値を取得するときに例外がスローされると、Micrometerは内部のロギング(InternalLogger)を使って警告ログを出力する。
+        // InternalLoggerの実体は、クラスパスにSLF4Jの実装が含まれていればそれを使用し、なければJULを使用する(InternalLoggerFactoryを参照)。
+        // ここでは、JULが使用されている前提で、例外発生時にJULに警告ログが出力されていること(例外を再スローできていること)をテストしている。
+        JMException jmException = new JMException("test");
+
+        new Expectations() {{
+            mBeanServer.getAttribute(objectName, attributeName); result = jmException;
+        }};
+
+        Gauge gauge = meterRegistry.find(metricsMetaData.getName()).gauge();
+
+        assertThat(gauge.value(), is(Double.NaN));
+
+        assertThat(mockJulHandler.getPublishedRecordList(), is(hasSize(1)));
+
+        LogRecord logRecord = mockJulHandler.getPublishedRecordList().get(0);
+        assertThat(logRecord.getLevel(), is(Level.WARNING));
+        assertThat(logRecord.getThrown().getCause(), is(jmException));
+    }
+
+    private Object[] toArray(Iterable<Tag> tags) {
+        List<Tag> list = new ArrayList<>();
+        tags.iterator().forEachRemaining(list::add);
+        return list.toArray();
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeConditionTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeConditionTest.java
@@ -1,0 +1,21 @@
+package nablarch.integration.micrometer.instrument.binder.jmx;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * {@link MBeanAttributeCondition}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class MBeanAttributeConditionTest {
+
+    @Test
+    public void testGetters() {
+        MBeanAttributeCondition sut = new MBeanAttributeCondition("objectName", "attribute");
+
+        assertThat(sut.getObjectName(), is("objectName"));
+        assertThat(sut.getAttribute(), is("attribute"));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetricsTest.java
@@ -3,6 +3,7 @@ package nablarch.integration.micrometer.instrument.binder.jvm;
 import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Meter;
 import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import mockit.Expectations;
 import mockit.Mocked;
@@ -14,7 +15,6 @@ import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Iterator;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -119,7 +119,7 @@ public class NablarchGcCountMetricsTest {
         NablarchGcCountMetrics metrics = new NablarchGcCountMetrics(
             "test.metrics",
             "Test metrics.",
-            Collections.singleton(Tag.of("fizz", "FIZZ"))
+            Tags.of("fizz", "FIZZ")
         );
         metrics.bindTo(registry);
 
@@ -142,7 +142,7 @@ public class NablarchGcCountMetricsTest {
         MetricsMetaData metricsMetaData = new MetricsMetaData(
                 "test.metrics.metadata",
                 "Test metrics metadata.",
-                Collections.singleton(Tag.of("buzz", "BUZZ"))
+                Tags.of("buzz", "BUZZ")
         );
         NablarchGcCountMetrics metrics = new NablarchGcCountMetrics(metricsMetaData);
         metrics.bindTo(registry);

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetricsTest.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import mockit.Expectations;
 import mockit.Mocked;
+import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -134,5 +135,29 @@ public class NablarchGcCountMetricsTest {
         assertThat(counter2Id.getTag("memory.manager.name"), is("memory-manager-2"));
         assertThat(counter2Id.getTag("fizz"), is("FIZZ"));
         assertThat(counter2Id.getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testCustomMetricsNameAndDescriptionAndTagWithMetircsMetaData() {
+        MetricsMetaData metricsMetaData = new MetricsMetaData(
+                "test.metrics.metadata",
+                "Test metrics metadata.",
+                Collections.singleton(Tag.of("buzz", "BUZZ"))
+        );
+        NablarchGcCountMetrics metrics = new NablarchGcCountMetrics(metricsMetaData);
+        metrics.bindTo(registry);
+
+        Collection<FunctionCounter> counters = registry.get("test.metrics.metadata").functionCounters();
+        Iterator<FunctionCounter> iterator = counters.iterator();
+
+        Meter.Id counter1Id = iterator.next().getId();
+        assertThat(counter1Id.getTag("memory.manager.name"), is("memory-manager-1"));
+        assertThat(counter1Id.getTag("buzz"), is("BUZZ"));
+        assertThat(counter1Id.getDescription(), is("Test metrics metadata."));
+
+        Meter.Id counter2Id = iterator.next().getId();
+        assertThat(counter2Id.getTag("memory.manager.name"), is("memory-manager-2"));
+        assertThat(counter2Id.getTag("buzz"), is("BUZZ"));
+        assertThat(counter2Id.getDescription(), is("Test metrics metadata."));
     }
 }

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -90,6 +90,15 @@ public class LogCountMetricsTest {
         publisher.write(ERROR_LOG_CONTEXT);
         publisher.write(FATAL_LOG_CONTEXT);
 
+        /*
+         * ログレベルのしきい値を検証をしている理由について
+         *
+         * LogCountMetrics(MetricsMetaData)は、ログレベルのしきい値を受け取らない。
+         * にもかかわらず、本テスト内ではログレベルのしきい値を検証している。
+         *
+         * これは、デフォルトのログレベルのしきい値(DEFAULT_LOG_LEVEL)が
+         * 正しく使用されていることを確認することが目的となっている。
+         */
         assertThat(findCounter(TRACE_LOG_CONTEXT, metricsName), is(nullValue()));
         assertThat(findCounter(DEBUG_LOG_CONTEXT, metricsName), is(nullValue()));
         assertThat(findCounter(INFO_LOG_CONTEXT, metricsName), is(nullValue()));

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -171,6 +171,21 @@ public class LogCountMetricsTest {
         assertThat(mockLogListener.count, is(2));
     }
 
+    @Test
+    public void testCountForEachLogLevels() {
+        sut.bindTo(registry);
+
+        String runtimeLoggerName = "TestLogger";
+        LogContext warnContext = new LogContext("TEST", runtimeLoggerName, LogLevel.WARN, "warn context", null);
+        LogContext errorContext = new LogContext("TEST", runtimeLoggerName, LogLevel.ERROR, "error context", null);
+
+        publisher.write(warnContext);
+        publisher.write(errorContext);
+
+        assertThat(findCounter(warnContext).count(), is(1.0));
+        assertThat(findCounter(errorContext).count(), is(1.0));
+    }
+
     private static class MockLogListener implements LogListener {
         private int count;
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -1,0 +1,183 @@
+package nablarch.integration.micrometer.instrument.binder.logging;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import nablarch.core.log.basic.LogContext;
+import nablarch.core.log.basic.LogLevel;
+import nablarch.core.log.basic.LogListener;
+import nablarch.core.log.basic.LogPublisher;
+import org.junit.After;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link LogCountMetrics}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class LogCountMetricsTest {
+    private static final LogContext TRACE_LOG_CONTEXT = new LogContext("TEST_LOGGER", "TraceLogger", LogLevel.TRACE, "trace log", null);
+    private static final LogContext DEBUG_LOG_CONTEXT = new LogContext("TEST_LOGGER", "DebugLogger", LogLevel.DEBUG, "debug log", null);
+    private static final LogContext INFO_LOG_CONTEXT = new LogContext("TEST_LOGGER", "InfoLogger", LogLevel.INFO, "info log", null);
+    private static final LogContext WARN_LOG_CONTEXT = new LogContext("TEST_LOGGER", "WarnLogger", LogLevel.WARN, "warn log", null);
+    private static final LogContext ERROR_LOG_CONTEXT = new LogContext("TEST_LOGGER", "ErrorLogger", LogLevel.ERROR, "error log", null);
+    private static final LogContext FATAL_LOG_CONTEXT = new LogContext("TEST_LOGGER", "FatalLogger", LogLevel.FATAL, "fatal log", null);
+
+    private final LogCountMetrics sut = new LogCountMetrics();
+    private final SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    private final LogPublisher publisher = new LogPublisher();
+
+    @Test
+    public void testCountLogWriteUpperThanInfoInDefault() {
+        sut.bindTo(registry);
+
+        publisher.write(TRACE_LOG_CONTEXT);
+        publisher.write(DEBUG_LOG_CONTEXT);
+        publisher.write(INFO_LOG_CONTEXT);
+        publisher.write(WARN_LOG_CONTEXT);
+        publisher.write(ERROR_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+
+        assertThat(findCounter(TRACE_LOG_CONTEXT), is(nullValue()));
+        assertThat(findCounter(DEBUG_LOG_CONTEXT), is(nullValue()));
+        assertThat(findCounter(INFO_LOG_CONTEXT), is(nullValue()));
+
+        assertThat(findCounter(WARN_LOG_CONTEXT), is(notNullValue()));
+        assertThat(findCounter(ERROR_LOG_CONTEXT), is(notNullValue()));
+        assertThat(findCounter(FATAL_LOG_CONTEXT), is(notNullValue()));
+    }
+
+    @Test
+    public void testCustomLogLevel() {
+        LogCountMetrics sut = new LogCountMetrics(LogLevel.INFO);
+        sut.bindTo(registry);
+
+        publisher.write(TRACE_LOG_CONTEXT);
+        publisher.write(DEBUG_LOG_CONTEXT);
+        publisher.write(INFO_LOG_CONTEXT);
+        publisher.write(WARN_LOG_CONTEXT);
+        publisher.write(ERROR_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+
+        assertThat(findCounter(TRACE_LOG_CONTEXT), is(nullValue()));
+        assertThat(findCounter(DEBUG_LOG_CONTEXT), is(nullValue()));
+
+        assertThat(findCounter(INFO_LOG_CONTEXT), is(notNullValue()));
+        assertThat(findCounter(WARN_LOG_CONTEXT), is(notNullValue()));
+        assertThat(findCounter(ERROR_LOG_CONTEXT), is(notNullValue()));
+        assertThat(findCounter(FATAL_LOG_CONTEXT), is(notNullValue()));
+    }
+
+    @Test
+    public void testCustomMetricsNameAndDescription() {
+        String metricsName = "test.metrics";
+        LogCountMetrics sut = new LogCountMetrics(metricsName, "Test metrics.");
+        sut.bindTo(registry);
+
+        publisher.write(TRACE_LOG_CONTEXT);
+        publisher.write(DEBUG_LOG_CONTEXT);
+        publisher.write(INFO_LOG_CONTEXT);
+        publisher.write(WARN_LOG_CONTEXT);
+        publisher.write(ERROR_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+
+        assertThat(findCounter(TRACE_LOG_CONTEXT, metricsName), is(nullValue()));
+        assertThat(findCounter(DEBUG_LOG_CONTEXT, metricsName), is(nullValue()));
+        assertThat(findCounter(INFO_LOG_CONTEXT, metricsName), is(nullValue()));
+
+        assertThat(findCounter(WARN_LOG_CONTEXT, metricsName), is(notNullValue()));
+        assertThat(findCounter(ERROR_LOG_CONTEXT, metricsName), is(notNullValue()));
+        assertThat(findCounter(FATAL_LOG_CONTEXT, metricsName), is(notNullValue()));
+
+        assertThat(findCounter(WARN_LOG_CONTEXT, metricsName).getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testCustomMetricsNameAndDescriptionAndLogLevel() {
+        String metricsName = "test.metrics";
+        LogCountMetrics sut = new LogCountMetrics(metricsName, "Test metrics.", LogLevel.ERROR);
+        sut.bindTo(registry);
+
+        publisher.write(TRACE_LOG_CONTEXT);
+        publisher.write(DEBUG_LOG_CONTEXT);
+        publisher.write(INFO_LOG_CONTEXT);
+        publisher.write(WARN_LOG_CONTEXT);
+        publisher.write(ERROR_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+
+        assertThat(findCounter(TRACE_LOG_CONTEXT, metricsName), is(nullValue()));
+        assertThat(findCounter(DEBUG_LOG_CONTEXT, metricsName), is(nullValue()));
+        assertThat(findCounter(INFO_LOG_CONTEXT, metricsName), is(nullValue()));
+        assertThat(findCounter(WARN_LOG_CONTEXT, metricsName), is(nullValue()));
+
+        assertThat(findCounter(ERROR_LOG_CONTEXT, metricsName), is(notNullValue()));
+        assertThat(findCounter(FATAL_LOG_CONTEXT, metricsName), is(notNullValue()));
+
+        assertThat(findCounter(FATAL_LOG_CONTEXT, metricsName).getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testCountNumberOfLoggingEvent() {
+        sut.bindTo(registry);
+
+        publisher.write(WARN_LOG_CONTEXT);
+
+        publisher.write(ERROR_LOG_CONTEXT);
+        publisher.write(ERROR_LOG_CONTEXT);
+
+        publisher.write(FATAL_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+        publisher.write(FATAL_LOG_CONTEXT);
+
+        assertThat(findCounter(WARN_LOG_CONTEXT).count(), is(1.0));
+        assertThat(findCounter(ERROR_LOG_CONTEXT).count(), is(2.0));
+        assertThat(findCounter(FATAL_LOG_CONTEXT).count(), is(3.0));
+
+        assertThat(findCounter(WARN_LOG_CONTEXT).getId().getDescription(), is(LogCountMetrics.DEFAULT_METRICS_DESCRIPTION));
+        assertThat(findCounter(ERROR_LOG_CONTEXT).getId().getDescription(), is(LogCountMetrics.DEFAULT_METRICS_DESCRIPTION));
+        assertThat(findCounter(FATAL_LOG_CONTEXT).getId().getDescription(), is(LogCountMetrics.DEFAULT_METRICS_DESCRIPTION));
+    }
+
+    @Test
+    public void testClose() {
+        sut.bindTo(registry);
+
+        MockLogListener mockLogListener = new MockLogListener();
+        LogPublisher.addListener(mockLogListener);
+
+        publisher.write(WARN_LOG_CONTEXT);
+
+        sut.close();
+
+        publisher.write(WARN_LOG_CONTEXT);
+
+        assertThat(findCounter(WARN_LOG_CONTEXT).count(), is(1.0));
+        assertThat(mockLogListener.count, is(2));
+    }
+
+    private static class MockLogListener implements LogListener {
+        private int count;
+
+        @Override
+        public void onWritten(LogContext context) {
+            count++;
+        }
+    }
+
+    @After
+    public void tearDown() {
+        LogPublisher.removeAllListeners();
+    }
+
+    private Counter findCounter(LogContext logContext) {
+        return findCounter(logContext, LogCountMetrics.DEFAULT_METRICS_NAME);
+    }
+
+    private Counter findCounter(LogContext logContext, String metricsName) {
+        return registry.find(metricsName)
+                .tag(LogCountMetrics.TAG_NAME_RUNTIME_LOGGER, logContext.getRuntimeLoggerName())
+                .tag(LogCountMetrics.TAG_NAME_LEVEL, logContext.getLevel().name())
+                .counter();
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -185,10 +185,27 @@ public class LogCountMetricsTest {
         LogPublisher.removeAllListeners();
     }
 
+    /**
+     * 指定されたログコンテキストの出力をカウントした {@link Counter} を、デフォルトのメトリクス名で検索する。
+     * <p>
+     * 該当する {@link Counter} が見つからない場合は {@code null} を返す。
+     * </p>
+     * @param logContext カウント対象のログコンテキスト
+     * @return ログコンテキストの出力をカウントした {@link Counter}
+     */
     private Counter findCounter(LogContext logContext) {
         return findCounter(logContext, LogCountMetrics.DEFAULT_METRICS_NAME);
     }
 
+    /**
+     * 指定されたログコンテキストの出力をカウントした {@link Counter} を、指定されたメトリクス名で検索する。
+     * <p>
+     * 該当する {@link Counter} が見つからない場合は {@code null} を返す。
+     * </p>
+     * @param logContext カウント対象のログコンテキスト
+     * @param metricsName メトリクス名
+     * @return ログコンテキストの出力をカウントした {@link Counter}
+     */
     private Counter findCounter(LogContext logContext, String metricsName) {
         return registry.find(metricsName)
                 .tag(LogCountMetrics.TAG_NAME_RUNTIME_LOGGER, logContext.getRuntimeLoggerName())

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -11,6 +11,7 @@ import nablarch.core.log.basic.LogPublisher;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 import org.junit.After;
 import org.junit.Test;
+import sun.rmi.runtime.Log;
 
 import java.util.Arrays;
 
@@ -184,6 +185,21 @@ public class LogCountMetricsTest {
 
         assertThat(findCounter(warnContext).count(), is(1.0));
         assertThat(findCounter(errorContext).count(), is(1.0));
+    }
+
+    @Test
+    public void testCountForEachRuntimeLoggers() {
+        sut.bindTo(registry);
+
+        LogLevel logLevel = LogLevel.WARN;
+        LogContext fooWarnContext = new LogContext("TEST", "foo", logLevel, "foo warn context", null);
+        LogContext barWarnContext = new LogContext("TEST", "bar", logLevel, "bar warn context", null);
+
+        publisher.write(fooWarnContext);
+        publisher.write(barWarnContext);
+
+        assertThat(findCounter(fooWarnContext).count(), is(1.0));
+        assertThat(findCounter(barWarnContext).count(), is(1.0));
     }
 
     private static class MockLogListener implements LogListener {

--- a/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
@@ -1,0 +1,171 @@
+package nablarch.integration.micrometer.instrument.dao;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import mockit.Expectations;
+import mockit.Mock;
+import mockit.Mocked;
+import nablarch.common.dao.DaoContext;
+import nablarch.common.dao.DaoContextFactory;
+import nablarch.common.dao.EntityList;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import javax.persistence.OptimisticLockException;
+import java.util.List;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.Assert.assertThrows;
+
+/**
+ * {@link SqlTimeMetricsDaoContextFactory}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class SqlTimeMetricsDaoContextFactoryTest {
+    private final SqlTimeMetricsDaoContextFactory sut = new SqlTimeMetricsDaoContextFactory();
+    private final MockDaoContext originalDaoContext = new MockDaoContext();
+    private final MeterRegistry meterRegistry = new SimpleMeterRegistry();
+
+    @Before
+    public void setUp() throws Exception {
+        sut.setDelegate(new MockDaoContextFactory(originalDaoContext));
+        sut.setMeterRegistry(meterRegistry);
+    }
+
+    @Test
+    public void testCreate() {
+        SqlTimeMetricsDaoContext daoContext = (SqlTimeMetricsDaoContext)sut.create();
+
+        assertThat(daoContext.getDelegate(), is(sameInstance(originalDaoContext)));
+        assertThat(daoContext.getMeterRegistry(), is(sameInstance(meterRegistry)));
+    }
+
+    @Test
+    public void testThrowsExceptionIfDelegateIsNull() {
+        sut.setDelegate(null);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, sut::create);
+
+        assertThat(exception.getMessage(), is("delegate is null."));
+    }
+
+    @Test
+    public void testThrowsExceptionIfMeterRegistryIsNull() {
+        sut.setMeterRegistry(null);
+
+        IllegalStateException exception = assertThrows(IllegalStateException.class, sut::create);
+
+        assertThat(exception.getMessage(), is("meterRegistry is null."));
+    }
+
+    @Test
+    public void testSetMetricsName() {
+        sut.setMetricsName("test.metrics");
+
+        SqlTimeMetricsDaoContext daoContext = (SqlTimeMetricsDaoContext) sut.create();
+
+        assertThat(daoContext.getMetricsName(), is("test.metrics"));
+    }
+
+    @Test
+    public void testSetMetricsDescription() {
+        sut.setMetricsDescription("Test description");
+
+        SqlTimeMetricsDaoContext daoContext = (SqlTimeMetricsDaoContext) sut.create();
+
+        assertThat(daoContext.getMetricsDescription(), is("Test description"));
+    }
+
+    private static class MockDaoContextFactory extends DaoContextFactory {
+        private final DaoContext daoContext;
+
+        private MockDaoContextFactory(DaoContext daoContext) {
+            this.daoContext = daoContext;
+        }
+
+        @Override
+        public DaoContext create() {
+            return daoContext;
+        }
+    }
+
+    private static class MockDaoContext implements DaoContext {
+
+        @Override
+        public <T> T findById(Class<T> entityClass, Object... id) {
+            return null;
+        }
+
+        @Override
+        public <T> EntityList<T> findAll(Class<T> entityClass) {
+            return null;
+        }
+
+        @Override
+        public <T> EntityList<T> findAllBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+            return null;
+        }
+
+        @Override
+        public <T> EntityList<T> findAllBySqlFile(Class<T> entityClass, String sqlId) {
+            return null;
+        }
+
+        @Override
+        public <T> T findBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+            return null;
+        }
+
+        @Override
+        public <T> long countBySqlFile(Class<T> entityClass, String sqlId, Object params) {
+            return 0;
+        }
+
+        @Override
+        public <T> int update(T entity) throws OptimisticLockException {
+            return 0;
+        }
+
+        @Override
+        public <T> void batchUpdate(List<T> entities) {
+
+        }
+
+        @Override
+        public <T> void insert(T entity) {
+
+        }
+
+        @Override
+        public <T> void batchInsert(List<T> entities) {
+
+        }
+
+        @Override
+        public <T> int delete(T entity) {
+            return 0;
+        }
+
+        @Override
+        public <T> void batchDelete(List<T> entities) {
+
+        }
+
+        @Override
+        public DaoContext page(long page) {
+            return null;
+        }
+
+        @Override
+        public DaoContext per(long per) {
+            return null;
+        }
+
+        @Override
+        public DaoContext defer() {
+            return null;
+        }
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextTest.java
@@ -1,0 +1,571 @@
+package nablarch.integration.micrometer.instrument.dao;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleConfig;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import mockit.Expectations;
+import mockit.Mocked;
+import mockit.Verifications;
+import nablarch.common.dao.DaoContext;
+import nablarch.common.dao.EntityList;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link SqlTimeMetricsDaoContext}の単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class SqlTimeMetricsDaoContextTest {
+    private static final MockEntity MOCK_ENTITY = new MockEntity();
+    private static final List<MockEntity> MOCK_ENTITY_LIST = Arrays.asList(new MockEntity(), new MockEntity(), new MockEntity());
+    private static final List<?> EMPTY_ENTITY_LIST = Collections.emptyList();
+    private static final Object PARAM = new Object();
+    private static final Object[] PARAMS = new Object[] {new Object(), new Object(), new Object()};
+
+    @Mocked
+    private DaoContext daoContext;
+
+    private SqlTimeMetricsDaoContext sut;
+    private SimpleMeterRegistry meterRegistry = new SimpleMeterRegistry(SimpleConfig.DEFAULT, new Clock() {
+        // 奇数番が計測開始時刻、偶数番が計測終了時刻を表す
+        Iterator<Long> monotonicTimes = Arrays.asList(
+            1000L, 2000L
+        ).iterator();
+
+        @Override
+        public long monotonicTime() {
+            return monotonicTimes.next();
+        }
+
+        @Override
+        public long wallTime() { return 0; }
+    });
+
+    @Before
+    public void setUp() {
+        sut = new SqlTimeMetricsDaoContext(daoContext, meterRegistry);
+    }
+
+    @Test
+    public void testBatchDelete() {
+        sut.batchDelete(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "batchDelete");
+
+        new Verifications() {{
+            daoContext.batchDelete(MOCK_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchDeleteWhenEntityListIsNull() {
+        sut.batchDelete(null);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchDelete(null); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchDeleteWhenEntityListIsEmpty() {
+        sut.batchDelete(EMPTY_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchDelete(EMPTY_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchDeleteCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.batchDelete(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testBatchInsert() {
+        sut.batchInsert(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "batchInsert");
+
+        new Verifications() {{
+            daoContext.batchInsert(MOCK_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchInsertWhenEntityListIsNull() {
+        sut.batchInsert(null);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchInsert(null); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchInsertWhenEntityListIsEmpty() {
+        sut.batchInsert(EMPTY_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchInsert(EMPTY_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchInsertCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.batchInsert(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testBatchUpdate() {
+        sut.batchUpdate(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "batchUpdate");
+
+        new Verifications() {{
+            daoContext.batchUpdate(MOCK_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchUpdateWhenEntityListIsNull() {
+        sut.batchUpdate(null);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchUpdate(null); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchUpdateWhenEntityListIsEmpty() {
+        sut.batchUpdate(EMPTY_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.batchUpdate(EMPTY_ENTITY_LIST); times = 1;
+        }};
+    }
+
+    @Test
+    public void testBatchUpdateCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.batchUpdate(MOCK_ENTITY_LIST);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testCountBySqlFile() {
+        new Expectations() {{
+            daoContext.countBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+            result = 1234L;
+        }};
+
+        long returnValue = sut.countBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+
+        assertThat(returnValue, is(1234L));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, "test-sql-id", "countBySqlFile");
+    }
+
+    @Test
+    public void testCountBySqlFileCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.countBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testDelete() {
+        new Expectations() {{
+            daoContext.delete(MOCK_ENTITY); result = 321;
+        }};
+
+        int returnValue = sut.delete(MOCK_ENTITY);
+
+        assertThat(returnValue, is(321));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "delete");
+    }
+
+    @Test
+    public void testDeleteWhenEntityIsNull() {
+        new Expectations() {{
+            daoContext.delete(null); result = 123;
+        }};
+
+        int returnValue = sut.delete(null);
+
+        assertThat(returnValue, is(123));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+    }
+
+    @Test
+    public void testDeleteCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.delete(MOCK_ENTITY);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testFindAll() {
+        EntityList<MockEntity> entityList = new EntityList<>(Arrays.asList(new MockEntity(), new MockEntity()));
+        new Expectations() {{
+            daoContext.findAll(MockEntity.class); result = entityList;
+        }};
+
+        EntityList<MockEntity> returnValue = sut.findAll(MockEntity.class);
+
+        assertThat(returnValue, is(sameInstance(entityList)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "findAll");
+    }
+
+    @Test
+    public void testFindAllCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.findAll(MockEntity.class);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testFindAllBySqlFile() {
+        EntityList<MockEntity> entityList = new EntityList<>(Arrays.asList(new MockEntity(), new MockEntity()));
+        new Expectations() {{
+            daoContext.findAllBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+            result = entityList;
+        }};
+
+        EntityList<MockEntity> returnValue = sut.findAllBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+
+        assertThat(returnValue, is(sameInstance(entityList)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, "test-sql-id", "findAllBySqlFile");
+    }
+
+    @Test
+    public void testFindAllBySqlFileCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.findAllBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testFindAllBySqlFileWithoutParams() {
+        EntityList<MockEntity> entityList = new EntityList<>(Arrays.asList(new MockEntity(), new MockEntity()));
+        new Expectations() {{
+            daoContext.findAllBySqlFile(MockEntity.class, "test-sql-id");
+            result = entityList;
+        }};
+
+        EntityList<MockEntity> returnValue = sut.findAllBySqlFile(MockEntity.class, "test-sql-id");
+
+        assertThat(returnValue, is(sameInstance(entityList)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, "test-sql-id", "findAllBySqlFile");
+    }
+
+    @Test
+    public void testFindAllBySqlFileWithoutParamsCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.findAllBySqlFile(MockEntity.class, "test-sql-id");
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testFindById() {
+        new Expectations() {{
+            daoContext.findById(MockEntity.class, PARAMS); result = MOCK_ENTITY;
+        }};
+
+        MockEntity returnValue = sut.findById(MockEntity.class, PARAMS);
+
+        assertThat(returnValue, is(sameInstance(MOCK_ENTITY)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "findById");
+    }
+
+    @Test
+    public void testFindByIdCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.findById(MockEntity.class, PARAMS);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testFindBySqlFile() {
+        new Expectations() {{
+            daoContext.findBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+            result = MOCK_ENTITY;
+        }};
+
+        MockEntity returnValue = sut.findBySqlFile(MockEntity.class, "test-sql-id", PARAM);
+
+        assertThat(returnValue, is(sameInstance(MOCK_ENTITY)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, "test-sql-id", "findBySqlFile");
+    }
+
+    @Test
+    public void testFindBySqlFileCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.findById(MockEntity.class, PARAMS);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testUpdate() {
+        new Expectations() {{
+            daoContext.update(MOCK_ENTITY); result = 33;
+        }};
+
+        int returnValue = sut.update(MOCK_ENTITY);
+
+        assertThat(returnValue, is(33));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "update");
+    }
+
+    @Test
+    public void testUpdateWhenEntityIsNull() {
+        new Expectations() {{
+            daoContext.update(null); result = 44;
+        }};
+
+        int returnValue = sut.update(null);
+
+        assertThat(returnValue, is(44));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+    }
+
+    @Test
+    public void testUpdateCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.update(MOCK_ENTITY);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testInsert() {
+        sut.insert(MOCK_ENTITY);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertTimerRecord(timer, SqlTimeMetricsDaoContext.TAG_VALUE_NO_SQL_ID, "insert");
+
+        new Verifications() {{
+            daoContext.insert(MOCK_ENTITY); times = 1;
+        }};
+    }
+
+    @Test
+    public void testInsertWhenEntityIsNull() {
+        sut.insert(null);
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.insert(null); times = 1;
+        }};
+    }
+
+    @Test
+    public void testInsertCustomMetricsNameAndDescription() {
+        sut.setMetricsName("test.metrics");
+        sut.setMetricsDescription("Test metrics.");
+
+        sut.insert(MOCK_ENTITY);
+
+        Timer timer = meterRegistry.find("test.metrics").timer();
+
+        assertThat(timer.getId().getDescription(), is("Test metrics."));
+    }
+
+    @Test
+    public void testPage() {
+        DaoContext returnValue = sut.page(40L);
+
+        assertThat(returnValue, is(sameInstance(sut)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.page(40L); times = 1;
+        }};
+    }
+
+    @Test
+    public void testPer() {
+        DaoContext returnValue = sut.per(30L);
+
+        assertThat(returnValue, is(sameInstance(sut)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.per(30L); times = 1;
+        }};
+    }
+
+    @Test
+    public void testDefer() {
+        DaoContext returnValue = sut.defer();
+
+        assertThat(returnValue, is(sameInstance(sut)));
+
+        Timer timer = meterRegistry.find(SqlTimeMetricsDaoContext.DEFAULT_METRICS_NAME).timer();
+        assertThat(timer, is(nullValue()));
+
+        new Verifications() {{
+            daoContext.defer(); times = 1;
+        }};
+    }
+
+    @Test
+    public void testGetMetricsName() {
+        sut.setMetricsName("foo");
+
+        String metricsName = sut.getMetricsName();
+
+        assertThat(metricsName, is("foo"));
+    }
+
+    @Test
+    public void testGetMetricsDescription() {
+        sut.setMetricsDescription("bar");
+
+        String metricsDescription = sut.getMetricsDescription();
+
+        assertThat(metricsDescription, is("bar"));
+    }
+
+    private void assertTimerRecord(Timer timer, String expectedSqlId, String expectedMethodName) {
+        Meter.Id id = timer.getId();
+
+        assertThat("sql.id tag",
+                id.getTag(SqlTimeMetricsDaoContext.TAG_NAME_SQL_ID), is(expectedSqlId));
+        assertThat("entity tag",
+                id.getTag(SqlTimeMetricsDaoContext.TAG_NAME_ENTITY_NAME), is(MockEntity.class.getName()));
+        assertThat("method tag",
+                id.getTag(SqlTimeMetricsDaoContext.TAG_NAME_METHOD_NAME), is(expectedMethodName));
+        assertThat("metrics description",
+                id.getDescription(), is(SqlTimeMetricsDaoContext.DEFAULT_METRICS_DESCRIPTION));
+
+        assertThat("recorded time", timer.totalTime(TimeUnit.NANOSECONDS), is(1000.0));
+    }
+
+    @Test
+    public void testGetDelegate() {
+        assertThat(sut.getDelegate(), is(sameInstance(daoContext)));
+    }
+
+    public static class MockEntity {
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
@@ -28,6 +28,9 @@ public class TimerMetricsHandlerPercentilesTest {
     private final ExecutionContext context = new ExecutionContext();
 
     private final TimerMetricsHandler<String, String> sut = new TimerMetricsHandler<>();
+
+    // SimpleMeterRegistry はパーセンタイル近似をサポートしない設定のため、ヒストグラムのバケットが取得できない。
+    // このため本テストでは、パーセンタイル近似をサポートしているPrometheusMeterRegistryを利用している。
     private final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
     @Before

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
@@ -3,13 +3,11 @@ package nablarch.integration.micrometer.instrument.handler;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
 import io.micrometer.core.instrument.distribution.CountAtBucket;
-import io.micrometer.core.instrument.distribution.HistogramSnapshot;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;
-import mockit.Expectations;
-import mockit.Mocked;
 import nablarch.fw.ExecutionContext;
+import nablarch.fw.Handler;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -27,17 +25,14 @@ import static org.hamcrest.Matchers.*;
  * @author Tanaka Tomoyuki
  */
 public class TimerMetricsHandlerPercentilesTest {
-    @Mocked
-    private ExecutionContext context;
+    private final ExecutionContext context = new ExecutionContext();
 
     private final TimerMetricsHandler<String, String> sut = new TimerMetricsHandler<>();
     private final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
 
     @Before
     public void setUp() {
-        new Expectations() {{
-            context.handleNext("PARAM"); result = "RESULT";
-        }};
+        context.addHandler((Handler<String, String>) (param, context) -> "RESULT");
 
         sut.setMeterRegistry(meterRegistry);
         sut.setHandlerMetricsMetaDataBuilder(metricsMetaDataBuilder);

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
@@ -14,6 +14,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -87,8 +88,8 @@ public class TimerMetricsHandlerPercentilesTest {
 
         Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
 
-        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
-        assertThat(buckets, hasItems(9.0e10, 9.9e10));
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(cab -> cab.bucket(TimeUnit.MILLISECONDS)).collect(Collectors.toList());
+        assertThat(buckets, hasItems(90000.0, 99000.0));
     }
 
     @Test
@@ -100,8 +101,8 @@ public class TimerMetricsHandlerPercentilesTest {
 
         Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
 
-        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
-        assertThat(buckets, hasItems(9.87E8));
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(cab -> cab.bucket(TimeUnit.MILLISECONDS)).collect(Collectors.toList());
+        assertThat(buckets, hasItems(987.0));
     }
 
     @Test
@@ -113,8 +114,8 @@ public class TimerMetricsHandlerPercentilesTest {
 
         Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
 
-        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
-        assertThat(buckets, hasItems(4.5678E10));
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(cab -> cab.bucket(TimeUnit.MILLISECONDS)).collect(Collectors.toList());
+        assertThat(buckets, hasItems(45678.0));
     }
 
     private HandlerMetricsMetaDataBuilder<String, String> metricsMetaDataBuilder = new HandlerMetricsMetaDataBuilder<String, String>() {

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
@@ -1,0 +1,138 @@
+package nablarch.integration.micrometer.instrument.handler;
+
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.distribution.CountAtBucket;
+import io.micrometer.core.instrument.distribution.HistogramSnapshot;
+import io.micrometer.core.instrument.distribution.ValueAtPercentile;
+import io.micrometer.prometheus.PrometheusConfig;
+import io.micrometer.prometheus.PrometheusMeterRegistry;
+import mockit.Expectations;
+import mockit.Mocked;
+import nablarch.fw.ExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+
+/**
+ * {@link TimerMetricsHandler}のパーセンタイルに関する設定のテストを行う単体テスト。
+ * @author Tanaka Tomoyuki
+ */
+public class TimerMetricsHandlerPercentilesTest {
+    @Mocked
+    private ExecutionContext context;
+
+    private final TimerMetricsHandler<String, String> sut = new TimerMetricsHandler<>();
+    private final PrometheusMeterRegistry meterRegistry = new PrometheusMeterRegistry(PrometheusConfig.DEFAULT);
+
+    @Before
+    public void setUp() {
+        new Expectations() {{
+            context.handleNext("PARAM"); result = "RESULT";
+        }};
+
+        sut.setMeterRegistry(meterRegistry);
+        sut.setHandlerMetricsMetaDataBuilder(metricsMetaDataBuilder);
+    }
+
+    @Test
+    public void testSetPercentiles() {
+        sut.setPercentiles(Arrays.asList("0.95", "0.5"));
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        ValueAtPercentile[] valueAtPercentiles = timer.takeSnapshot().percentileValues();
+        assertThat(valueAtPercentiles, arrayWithSize(2));
+
+        List<Double> percentiles = Stream.of(valueAtPercentiles).map(ValueAtPercentile::percentile).collect(Collectors.toList());
+        assertThat(percentiles, containsInAnyOrder(0.95, 0.5));
+    }
+
+    @Test
+    public void testSetEnablePercentileHistogramWhenDisable() {
+        sut.setEnablePercentileHistogram(false);
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        assertThat(timer.takeSnapshot().histogramCounts(), is(emptyArray()));
+    }
+
+    @Test
+    public void testSetEnablePercentileHistogramWhenEnable() {
+        sut.setEnablePercentileHistogram(true);
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        assertThat(timer.takeSnapshot().histogramCounts(), is(not(emptyArray())));
+    }
+
+    @Test
+    public void testSetServiceLevelObjectives() {
+        sut.setEnablePercentileHistogram(true);
+        sut.setServiceLevelObjectives(Arrays.asList("90000", "99000"));
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
+        assertThat(buckets, hasItems(9.0e10, 9.9e10));
+    }
+
+    @Test
+    public void testSetMinimumExpectedValue() {
+        sut.setEnablePercentileHistogram(true);
+        sut.setMinimumExpectedValue(987L);
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
+        assertThat(buckets, hasItems(9.87E8));
+    }
+
+    @Test
+    public void testSetMaximumExpectedValue() {
+        sut.setEnablePercentileHistogram(true);
+        sut.setMaximumExpectedValue(45678L);
+
+        sut.handle("PARAM", context);
+
+        Timer timer = meterRegistry.find(metricsMetaDataBuilder.getMetricsName()).timer();
+
+        List<Double> buckets = Stream.of(timer.takeSnapshot().histogramCounts()).map(CountAtBucket::bucket).collect(Collectors.toList());
+        assertThat(buckets, hasItems(4.5678E10));
+    }
+
+    private HandlerMetricsMetaDataBuilder<String, String> metricsMetaDataBuilder = new HandlerMetricsMetaDataBuilder<String, String>() {
+        @Override
+        public String getMetricsName() {
+            return "test.metrics";
+        }
+
+        @Override
+        public String getMetricsDescription() {
+            return "Test metrics.";
+        }
+
+        @Override
+        public List<Tag> buildTagList(String param, ExecutionContext executionContext, String s, Throwable thrownThrowable) {
+            return Collections.emptyList();
+        }
+    };
+}


### PR DESCRIPTION
全部で６つの修正が含まれています。

1. ログレベルごとのログ出力回数をカウント
2. バッチの処理件数をカウント
3. HTTPリクエスト処理時間のパーセンタイルをとれるようにする
4. SQLの処理時間を計測できるようにする
5. JMX 経由でメトリクスを収集する汎用部品を作る
6. リファクタリング


## 1. ログレベルごとのログ出力回数をカウント
### コミット・関連PR
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/23d7beb3320c545ed4811a0c41626b601a1e2b1c
- https://github.com/nablarch/nablarch-core-applog/pull/11

### 説明
ログレベル・実行時ロガー名（`LoggerManager.getLogger(String)` の引数に渡す値）ごとに、ログの出力回数をカウントするメトリクス機能を追加しました。

`nablarch-core-applog` に、 `LogPublisher` という `LogWriter` インタフェースを実装したクラスを追加しました（[nablarch-core-applog の PR](https://github.com/nablarch/nablarch-core-applog/pull/11) も合わせてご確認ください）。  
この `LogPublisher` は、出力されたログの情報(`LogContext`)を事前登録された任意のリスナー(`LogListener`)に公開する機能を提供します。

ログ出力回数を計測するための `LogCountMetrics` クラスは、この `LogPublihser` にリスナーを追加します。  
リスナーは、受け取った `LogContext` の情報をもとにログレベル・実行時ロガー名ごとの出力回数をカウントしていきます。

当初の要望が WARN レベル以上を記録したいというものだったので、デフォルトは WARN 以上のものだけカウントするようにしていますが、コンストラクタ引数で `LogLevel` を渡すことで変更はできるようにしています。

## 2. バッチの処理件数をカウント
### コミット
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/d247dd43b4c8fa6e20a206d6d6f0d8a916825489

### 説明
バッチの処理件数をカウントする、 `CommitLogger` の実装クラス(`BatchProcessedRecordCountMetricsLogger`)を追加しました。

もともとは「トランザクションごとのコミット件数」という形で要望として挙がっていたメトリクスですが、ヒアリングの結果「バッチの進捗状況を可視化すること」が目的だったため、「バッチの処理件数をカウント」するメトリクスとなったものです。

Nablarch の [CommitLogger](https://nablarch.github.io/docs/5u7/javadoc/nablarch/core/log/app/CommitLogger.html) の仕組みを利用しています。  
Nablarch のバッチは [トランザクションループ制御ハンドラ](https://nablarch.github.io/docs/LATEST/doc/application_framework/application_framework/handlers/batch/loop_handler.html#loop-handler) によって、一定件数の入力データを処理するごとにコミットするようになっています。  
`CommitLogger` はコミットのタイミングで `increment(int)` メソッドがコールされ、引数にそのトランザクション内で処理した入力データ件数が渡されます。

`BatchProcessedRecordCountMetricsLogger` は、受け取った「処理した入力データ件数」を加算していく実装になっています。

## 3. HTTPリクエスト処理時間のパーセンタイルをとれるようにする
### コミット
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/f8923407ab6f553e094ee5268f3f4912625359cb

HTTP リクエストの処理時間のメトリクスで、パーセンタイルも収集できるようにする対応です。

Micrometer は、 `Timer` を作るときに `publishPercentiles(double...)` などのメソッドで収集したいパーセンタイルの情報をセットアップすることで、パーセンタイルの情報を収集できるようになっています。

- [13. Histograms and percentiles](https://micrometer.io/docs/concepts#_histograms_and_percentiles)

この修正では、 `TimerMetricsHandler` にこれらパーセンタイル用の設定を渡せるようにするプロパティを追加する対応をいれています。

### 説明

## 4. SQLの処理時間を計測できるようにする
### コミット
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/6f9a4b0fe05ae6e36c6a8ab587666665e5d077c3

`DaoContext` をラップして、SQLの処理時間をメトリクスとして収集する `SqlTimeMetricsDaoContext` を追加しました。

SQLIDを受け取るメソッド（`findBySqlFile()` など）は SQLID をタグに出力しますが、そうでないメソッド(`findAll()` や `update()`, `insert()` など)もあるので、  
「エンティティクラスの名前」と「コールされた `DaoContext` のメソッド名」をタグに含めるようにしています。  
（SQLID がない場合は `"None"` 固定）

### 説明

## 5. JMX 経由でメトリクスを収集する汎用部品を作る
### コミット
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/6a30817b4613991724f634a7dca2df93b97578e7

### 説明
オブジェクト名と属性名で任意の MBean の属性値を指定し、 Gauge (上下する数値のメーター)として収集する `JmxGaugeMetrics` を追加しました。

`JmxGaugeMetrics` に渡すパラメータ（メトリクス名、説明、タグ一覧、オブジェクト名、属性名）を全てそのままコンストラクタで渡すと、引数が `String` だらけになって分かりづらくなると思ったので、 `MetricsMetaData` (メトリクス名、説明、タグ一覧) と `MBeanAttributeCondition` (オブジェクト名、属性名) の入れ物クラスに分けています。

## 6. リファクタリング
### コミット
- https://github.com/nablarch/nablarch-micrometer-adaptor/pull/8/commits/e8101c236ea28d80673465610783f523b768f347

### 説明
`JmxGaugeMetrics` の対応で追加した `MetricsMetaData` を、他の `MeterBinder` 実装クラスでも利用するようにするリファクタリングです。

`MetricsMetaData` 自体は `JmxGaugeMetrics` の引数を整理するために追加したものです。  
しかし、内容的に他のクラスでも使える汎用的な存在なので `JmxGaugeMetrics` だけで使用しているというのも後から見たときに不自然かと思いました（汎用的なクラスっぽいのに、なんで `JmxGaugeMetrics` でしか使われてないんだろう？　他では使ってはダメな理由があるのだろうか？　というような判断しづらい状態にならないように）。  

そこで、他の `MeterBinder` を実装したクラスでも利用するように修正したのが、このリファクタリング対応です。

対応を `MeterBinder` の実装クラスに限定しているのは、これ以外のクラス([BatchProcessedRecordCountMetricsLogger](https://github.com/nablarch/nablarch-micrometer-adaptor/blob/feature-NAB-387/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchProcessedRecordCountMetricsLogger.java)など)はいずれもコンポーネント定義ファイルでプロパティとしてメトリクス名などを設定する作りだからです。  
（無理に `MetricsMetaData` を使うようにすると、コンポーネント定義ファイルの記述が膨らむ）

[NablarchGcCountMetrics](https://github.com/nablarch/nablarch-micrometer-adaptor/blob/feature-NAB-387/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java#L65) は前回のリリースですでに公開されているので、既存のコンストラクタは触らずに `MetricsMetaData` を受け取れるコンストラクタを追加するだけにしています。