### PR TITLE
Azure対応

### DIFF
--- a/src/main/java/nablarch/integration/micrometer/GlobalMeterRegistryFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/GlobalMeterRegistryFactory.java
@@ -1,0 +1,22 @@
+package nablarch.integration.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+
+/**
+ * Micrometerのグローバルレジストリ({@code io.micrometer.core.instrument.Metrics.globalRegistry})を
+ * コンポーネントとして生成するファクトリクラス。
+ * @author Tanaka Tomoyuki
+ */
+public class GlobalMeterRegistryFactory extends MeterRegistryFactory<MeterRegistry> {
+
+    @Override
+    public MeterRegistry createObject() {
+        return doCreateObject();
+    }
+
+    @Override
+    protected MeterRegistry createMeterRegistry(MicrometerConfiguration micrometerConfiguration) {
+        return Metrics.globalRegistry;
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/GlobalMeterRegistryFactoryTest.java
+++ b/src/test/java/nablarch/integration/micrometer/GlobalMeterRegistryFactoryTest.java
@@ -1,0 +1,28 @@
+package nablarch.integration.micrometer;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Metrics;
+import nablarch.core.repository.disposal.BasicApplicationDisposer;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.sameInstance;
+
+/**
+ * {@link GlobalMeterRegistryFactory}の単体テストクラス。
+ * @author Tanaka Tomoyuki
+ */
+public class GlobalMeterRegistryFactoryTest {
+
+    @Test
+    public void testCreateObjectReturnsGlobalRegistry() {
+        GlobalMeterRegistryFactory sut = new GlobalMeterRegistryFactory();
+        sut.setMeterBinderListProvider(new DefaultMeterBinderListProvider());
+        sut.setApplicationDisposer(new BasicApplicationDisposer());
+
+        MeterRegistry meterRegistry = sut.createObject();
+
+        assertThat(meterRegistry, is(sameInstance(Metrics.globalRegistry)));
+    }
+}


### PR DESCRIPTION
# 概要
Micrometer で収集したメトリクスを Azure に連携できるようにする対応を実施。

# Azure にメトリクスを連携する方法について
Java アプリケーションから Azure (Application Insights)にメトリクスを連携するには、 Java エージェントを使用する。

- [Azure Monitor Application Insights を監視する Java のコード不要のアプリケーション](https://docs.microsoft.com/ja-jp/azure/azure-monitor/app/java-in-process-agent)

Java エージェントは、 Micrometer の[グローバルレジストリ](https://micrometer.io/docs/concepts#_global_registry)をフックして、 Application Insights にメトリクスを連携する仕組みを提供している。

- [Micrometer を使用してカスタム　メトリックを送信する](https://docs.microsoft.com/ja-jp/azure/azure-monitor/app/java-in-process-agent#send-custom-metrics-using-micrometer)

つまり、アプリケーションとしては Micrometer のグローバルレジストリを使ってメトリクスを計測するように実装しておけば、あとは Java エージェントがメトリクスを Azure に連携してくれるようになっている。

# Micrometer アダプタでの対応
グローバルレジストリをコンポーネントとして使えるようにするため、 [GlobalMeterRegistryFactory](https://github.com/nablarch/nablarch-micrometer-adaptor/blob/feature-NAB-395/src/main/java/nablarch/integration/micrometer/GlobalMeterRegistryFactory.java) を追加した。

レジストリファクトリにこのクラスを使用すれば、あとは Azure の Java エージェントがメトリクスの連携をしてくれるようになる。

なお、レジストリに対する設定（送信間隔の指定など）は Java エージェントが行うため、 Micrometer アダプタで用意している設定方法（`micrometer.properties` を使った設定）は利用できない。
このため、 `GlobalMeterRegistryFactory` の `createMeterRegistry()` で受け取っている `MicrometerConfiguration` は[一切使用しない（できない）形になっている](https://github.com/nablarch/nablarch-micrometer-adaptor/blob/feature-NAB-395/src/main/java/nablarch/integration/micrometer/GlobalMeterRegistryFactory.java#L19)。