### PR TITLE
Jakarta EE対応

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,23 +22,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <maven.compiler.source>1.8</maven.compiler.source>
-    <maven.compiler.target>1.8</maven.compiler.target>
     <version.micrometer>1.5.4</version.micrometer>
   </properties>
-
-  <profiles>
-    <profile>
-      <id>java11</id>
-      <dependencies>
-        <dependency>
-          <groupId>com.sun.activation</groupId>
-          <artifactId>javax.activation</artifactId>
-          <scope>test</scope>
-        </dependency>
-      </dependencies>
-    </profile>
-  </profiles>
 
   <dependencies>
     <dependency>
@@ -98,10 +83,15 @@
     </dependency>
 
     <dependency>
-      <groupId>javax.servlet</groupId>
-      <artifactId>javax.servlet-api</artifactId>
-      <version>3.1.0</version>
+      <groupId>jakarta.servlet</groupId>
+      <artifactId>jakarta.servlet-api</artifactId>
       <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.eclipse.angus</groupId>
+      <artifactId>angus-activation</artifactId>
+      <scope>test</scope>
     </dependency>
 
     <dependency>

--- a/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContext.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContext.java
@@ -5,7 +5,7 @@ import io.micrometer.core.instrument.Timer;
 import nablarch.common.dao.DaoContext;
 import nablarch.common.dao.EntityList;
 
-import javax.persistence.OptimisticLockException;
+import jakarta.persistence.OptimisticLockException;
 import java.util.List;
 import java.util.function.Supplier;
 

--- a/src/main/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilder.java
@@ -7,7 +7,7 @@ import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import nablarch.integration.micrometer.instrument.handler.HandlerMetricsMetaDataBuilder;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.List;

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -11,7 +11,6 @@ import nablarch.core.log.basic.LogPublisher;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 import org.junit.After;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.util.Arrays;
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
@@ -12,7 +12,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 
-import javax.persistence.OptimisticLockException;
+import jakarta.persistence.OptimisticLockException;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilderOutcomeTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilderOutcomeTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilderTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/http/HttpRequestTimeMetricsMetaDataBuilderTest.java
@@ -8,7 +8,7 @@ import nablarch.fw.web.HttpRequest;
 import nablarch.fw.web.servlet.ServletExecutionContext;
 import org.junit.Test;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 import java.util.List;
 
 import static org.hamcrest.MatcherAssert.assertThat;


### PR DESCRIPTION
`sun.rmi.runtime.Log` は間違って import していたもので、 Java 17 でコンパイルしようとすると内部APIの参照エラーになるため除去しました。