### PR TITLE
[Draft]Add OpenTelemetry(otlp) metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,13 @@
     </dependency>
 
     <dependency>
+      <groupId>io.micrometer</groupId>
+      <artifactId>micrometer-registry-otlp</artifactId>
+      <version>1.9.17</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>com.nablarch.framework</groupId>
       <artifactId>nablarch-core-repository</artifactId>
     </dependency>

--- a/src/main/java/nablarch/integration/micrometer/otlp/NablarchOtlpConfig.java
+++ b/src/main/java/nablarch/integration/micrometer/otlp/NablarchOtlpConfig.java
@@ -1,0 +1,26 @@
+package nablarch.integration.micrometer.otlp;
+
+import io.micrometer.registry.otlp.OtlpConfig;
+import nablarch.core.repository.di.DiContainer;
+import nablarch.integration.micrometer.NablarchMeterRegistryConfig;
+
+/**
+ * {@link NablarchMeterRegistryConfig}を用いて{@link OtlpConfig}を実装したクラス。
+ * @author Junya Koyama
+ */
+public class NablarchOtlpConfig extends NablarchMeterRegistryConfig implements OtlpConfig {
+    /**
+     * プレフィックスと{@link DiContainer}を指定してインスタンスを生成する。
+     *
+     * @param prefix      プレフィックス
+     * @param diContainer {@link DiContainer}
+     */
+    public NablarchOtlpConfig(String prefix, DiContainer diContainer) {
+        super(prefix, diContainer);
+    }
+
+    @Override
+    protected String subPrefix() {
+        return "otlp";
+    }
+}

--- a/src/main/java/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory.java
+++ b/src/main/java/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory.java
@@ -1,0 +1,24 @@
+package nablarch.integration.micrometer.otlp;
+
+import io.micrometer.core.instrument.Clock;
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import nablarch.integration.micrometer.MeterRegistryFactory;
+import nablarch.integration.micrometer.MicrometerConfiguration;
+
+/**
+ * {@link OtlpMeterRegistry}のファクトリ。
+ * @author Junya Koyama
+ */
+public class OtlpMeterRegistryFactory extends MeterRegistryFactory<OtlpMeterRegistry> {
+
+    @Override
+    public OtlpMeterRegistry createObject() {
+        return doCreateObject();
+    }
+
+    @Override
+    protected OtlpMeterRegistry createMeterRegistry(MicrometerConfiguration micrometerConfiguration) {
+        NablarchOtlpConfig config = new NablarchOtlpConfig(prefix, micrometerConfiguration);
+        return new OtlpMeterRegistry(config, Clock.SYSTEM);
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/otlp/NablarchOtlpConfigTest.java
+++ b/src/test/java/nablarch/integration/micrometer/otlp/NablarchOtlpConfigTest.java
@@ -1,0 +1,19 @@
+package nablarch.integration.micrometer.otlp;
+
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * {@link NablarchOtlpConfig}の単体テスト。
+ * @author Junya Koyama
+ */
+public class NablarchOtlpConfigTest {
+
+    @Test
+    public void testSubPrefix() {
+        NablarchOtlpConfig sut = new NablarchOtlpConfig(null, null);
+        assertThat(sut.subPrefix(), is("otlp"));
+    }
+}

--- a/src/test/java/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactoryTest.java
+++ b/src/test/java/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactoryTest.java
@@ -1,0 +1,31 @@
+package nablarch.integration.micrometer.otlp;
+
+import io.micrometer.registry.otlp.OtlpMeterRegistry;
+import mockit.Deencapsulation;
+import nablarch.core.repository.disposal.BasicApplicationDisposer;
+import nablarch.integration.micrometer.DefaultMeterBinderListProvider;
+import org.junit.Test;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+/**
+ * {@link OtlpMeterRegistryFactory}の単体テスト。
+ * @author Junya Koyama
+ */
+public class OtlpMeterRegistryFactoryTest {
+
+    @Test
+    public void testCreateObject() {
+        OtlpMeterRegistryFactory sut = new OtlpMeterRegistryFactory();
+        sut.setApplicationDisposer(new BasicApplicationDisposer());
+        sut.setMeterBinderListProvider(new DefaultMeterBinderListProvider());
+        sut.setPrefix("test.otlp");
+        sut.setXmlConfigPath("nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.xml");
+
+        OtlpMeterRegistry meterRegistry = sut.createObject();
+
+        NablarchOtlpConfig config = Deencapsulation.getField(meterRegistry, "config");
+        assertThat(config.url(), is("http://localhost:4318/v1/metrics"));
+    }
+}

--- a/src/test/resources/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.properties
+++ b/src/test/resources/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.properties
@@ -1,0 +1,1 @@
+test.otlp.url=http://localhost:4318/v1/metrics

--- a/src/test/resources/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.xml
+++ b/src/test/resources/nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component-configuration
+        xmlns="http://tis.co.jp/nablarch/component-configuration"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://tis.co.jp/nablarch/component-configuration https://nablarch.github.io/schema/component-configuration.xsd">
+
+  <config-file file="nablarch/integration/micrometer/otlp/OtlpMeterRegistryFactory/testCreateObject/test.properties" />
+</component-configuration>


### PR DESCRIPTION
### 概要

[OpenTelemetry Protocol (OTLP)](https://micrometer.io/docs/registry/otlp) アダプター機能を追加します

NewRelic含む多くのAPMベンダーは[OpenTelemetry Protocol (OTLP)](https://micrometer.io/docs/registry/otlp) に対応しているので、この機能1つで、実質複数のAPMに対応可能になります。

Draftプルリクエストの方向性が「受け入れ可能」であれば、追加のE2Eテストやdocsの追加を行います

### 制限

[OpenTelemetry Protocol (OTLP)](https://micrometer.io/docs/registry/otlp) アダプターは、Micrometer1.9以降のサポートです。

したがって、意図的に現在のバージョン(1.5)と異なるバージョンを使用します。