### PR TITLE
公開APIを追加

### DIFF
--- a/src/main/java/nablarch/integration/micrometer/DefaultMeterBinderListProvider.java
+++ b/src/main/java/nablarch/integration/micrometer/DefaultMeterBinderListProvider.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.binder.system.UptimeMetrics;
 import nablarch.core.log.Logger;
 import nablarch.core.log.LoggerManager;
 import nablarch.core.repository.disposal.Disposable;
+import nablarch.core.util.annotation.Published;
 import nablarch.integration.micrometer.instrument.binder.jvm.NablarchGcCountMetrics;
 
 import java.util.Arrays;
@@ -30,6 +31,7 @@ import java.util.List;
  * </p>
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class DefaultMeterBinderListProvider implements MeterBinderListProvider, Disposable {
     /** ロガー。 */
     private static final Logger LOGGER = LoggerManager.get(DefaultMeterBinderListProvider.class);

--- a/src/main/java/nablarch/integration/micrometer/cloudwatch/CloudWatchAsyncClientProvider.java
+++ b/src/main/java/nablarch/integration/micrometer/cloudwatch/CloudWatchAsyncClientProvider.java
@@ -1,11 +1,13 @@
 package nablarch.integration.micrometer.cloudwatch;
 
+import nablarch.core.util.annotation.Published;
 import software.amazon.awssdk.services.cloudwatch.CloudWatchAsyncClient;
 
 /**
  * {@link CloudWatchAsyncClient}のインスタンスを提供するインターフェース。
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public interface CloudWatchAsyncClientProvider {
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/batch/BatchTransactionTimeMetricsLogger.java
@@ -7,8 +7,6 @@ import io.micrometer.core.instrument.Timer;
 import nablarch.core.ThreadContext;
 import nablarch.core.log.app.CommitLogger;
 
-import java.util.Collections;
-
 /**
  * バッチのトランザクションごとの処理時間をメトリクスとして計測するロガー。
  * <p>

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/MetricsMetaData.java
@@ -1,6 +1,7 @@
 package nablarch.integration.micrometer.instrument.binder;
 
 import io.micrometer.core.instrument.Tag;
+import nablarch.core.util.annotation.Published;
 
 import java.util.Collections;
 
@@ -9,6 +10,7 @@ import java.util.Collections;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class MetricsMetaData {
     /** メトリクス名。 */
     private final String name;

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/JmxGaugeMetrics.java
@@ -3,6 +3,7 @@ package nablarch.integration.micrometer.instrument.binder.jmx;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import nablarch.core.util.annotation.Published;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 
 import javax.management.JMException;
@@ -15,6 +16,7 @@ import java.lang.management.ManagementFactory;
  *
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class JmxGaugeMetrics implements MeterBinder {
     /** メトリクスのメタ情報。 */
     private final MetricsMetaData metricsMetaData;

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jmx/MBeanAttributeCondition.java
@@ -1,9 +1,12 @@
 package nablarch.integration.micrometer.instrument.binder.jmx;
 
+import nablarch.core.util.annotation.Published;
+
 /**
  * JMXで取得するMBeanのAttributeを特定するための、オブジェクト名と属性名を保持したデータクラス。
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class MBeanAttributeCondition {
     /** オブジェクト名。 */
     private final String objectName;

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/jvm/NablarchGcCountMetrics.java
@@ -4,6 +4,7 @@ import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import nablarch.core.util.annotation.Published;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 
 import java.lang.management.GarbageCollectorMXBean;
@@ -19,6 +20,7 @@ import java.util.List;
  * </p>
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class NablarchGcCountMetrics implements MeterBinder {
     /** デフォルトのメトリクス名。 */
     static final String DEFAULT_METRICS_NAME = "jvm.gc.count";

--- a/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetrics.java
@@ -6,6 +6,7 @@ import io.micrometer.core.instrument.binder.MeterBinder;
 import nablarch.core.log.basic.LogLevel;
 import nablarch.core.log.basic.LogListener;
 import nablarch.core.log.basic.LogPublisher;
+import nablarch.core.util.annotation.Published;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 
 import java.io.Closeable;
@@ -25,6 +26,7 @@ import java.io.Closeable;
  * </p>
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public class LogCountMetrics implements MeterBinder, Closeable {
     /** デフォルトのメトリクスの名前。 */
     static final String DEFAULT_METRICS_NAME = "log.count";

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/HandlerMetricsMetaDataBuilder.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/HandlerMetricsMetaDataBuilder.java
@@ -1,6 +1,7 @@
 package nablarch.integration.micrometer.instrument.handler;
 
 import io.micrometer.core.instrument.Tag;
+import nablarch.core.util.annotation.Published;
 import nablarch.fw.ExecutionContext;
 
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.List;
  * @param <TResult> 処理結果データ型
  * @author Tanaka Tomoyuki
  */
+@Published(tag = "architect")
 public interface HandlerMetricsMetaDataBuilder<TData, TResult> {
 
     /**

--- a/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
+++ b/src/main/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandler.java
@@ -8,7 +8,6 @@ import nablarch.fw.Handler;
 
 import java.time.Duration;
 import java.util.List;
-import java.util.stream.Collectors;
 
 /**
  * ハンドラキューに追加することで、後続処理の実行時間をメトリクスとして収集するハンドラクラス。

--- a/src/test/java/nablarch/integration/micrometer/cloudwatch/NablarchCloudWatchConfigTest.java
+++ b/src/test/java/nablarch/integration/micrometer/cloudwatch/NablarchCloudWatchConfigTest.java
@@ -1,6 +1,5 @@
 package nablarch.integration.micrometer.cloudwatch;
 
-import nablarch.integration.micrometer.datadog.DatadogMeterRegistryFactory;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;

--- a/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/binder/logging/LogCountMetricsTest.java
@@ -11,7 +11,6 @@ import nablarch.core.log.basic.LogPublisher;
 import nablarch.integration.micrometer.instrument.binder.MetricsMetaData;
 import org.junit.After;
 import org.junit.Test;
-import sun.rmi.runtime.Log;
 
 import java.util.Arrays;
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/dao/SqlTimeMetricsDaoContextFactoryTest.java
@@ -2,13 +2,9 @@ package nablarch.integration.micrometer.instrument.dao;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import mockit.Expectations;
-import mockit.Mock;
-import mockit.Mocked;
 import nablarch.common.dao.DaoContext;
 import nablarch.common.dao.DaoContextFactory;
 import nablarch.common.dao.EntityList;
-import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 

--- a/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
+++ b/src/test/java/nablarch/integration/micrometer/instrument/handler/TimerMetricsHandlerPercentilesTest.java
@@ -2,7 +2,6 @@ package nablarch.integration.micrometer.instrument.handler;
 
 import io.micrometer.core.instrument.Tag;
 import io.micrometer.core.instrument.Timer;
-import io.micrometer.core.instrument.distribution.CountAtBucket;
 import io.micrometer.core.instrument.distribution.ValueAtPercentile;
 import io.micrometer.prometheus.PrometheusConfig;
 import io.micrometer.prometheus.PrometheusMeterRegistry;


### PR DESCRIPTION
## `CloudWatchAsyncClientProvider`の公開API化
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#id21)でCloudWatchとの連携をカスタマイズするために`CloudWatchAsyncClientProvider`を実装するよう案内しているが、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。

## `HandlerMetricsMetaDataBuilder`の公開API化
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#micrometer-timer-metrics-handler)で、処理時間を計測するために`HandlerMetricsMetaDataBuilder`を実装するよう案内しているが、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。

## `DefaultMeterBinderListProvider`の公開API化
[解説書](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#id37)では、計測対象を追加するために`DefaultMeterBinderListProvider`を継承して拡張するよう案内しているが、公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。

## いくつかの`MeterBinder`の公開API化
以下、機能拡張時に利用するよう解説書で案内しているAPIが公開APIとなっていなかったため、アーキテクト向けの公開APIとしました。
- [`LogCountMetrics`](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#micrometer-log-count) （ログの出力回数の計測）
- [`JmxGaugeMetrics`](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#tomcat) （Tomcatのスレッドプールの状態取得）
  - 一緒に使用される`MetricsMetaData`および`MBeanAttributeCondition`も併せて公開API化
- [`NablarchGcCountMetrics`](https://nablarch.github.io/docs/LATEST/doc/application_framework/adaptors/micrometer_adaptor.html#micrometer-default-metrics) （GCカウントの計測）
